### PR TITLE
Improve credit optimizer initialization and context analysis

### DIFF
--- a/packages/credit-optimizer-mcp/src/tool-indexer.ts
+++ b/packages/credit-optimizer-mcp/src/tool-indexer.ts
@@ -10,6 +10,20 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve as pathResolve } from 'path';
 
+type RawToolRecord = {
+  tool_name?: string;
+  toolName?: string;
+  server_name?: string;
+  serverName?: string;
+  category?: string;
+  description?: string;
+  keywords?: string | string[];
+  use_cases?: string | string[];
+  useCases?: string | string[];
+  created_at?: number;
+  createdAt?: number;
+};
+
 export interface ToolDefinition {
   name: string;
   server: string;
@@ -17,6 +31,9 @@ export interface ToolDefinition {
   description: string;
   keywords: string[];
   useCases: string[];
+  score: number;
+  rank: number;
+  lastIndexedAt?: string;
 }
 
 export class ToolIndexer {
@@ -73,8 +90,83 @@ export class ToolIndexer {
   /**
    * Search for tools
    */
-  searchTools(query: string, limit: number = 10): any[] {
-    return this.db.searchTools(query, limit);
+  searchTools(query: string, limit: number = 10): ToolDefinition[] {
+    const normalizedQuery = (query ?? '').toString().trim();
+    if (!normalizedQuery) {
+      return [];
+    }
+
+    const raw = this.db.searchTools(normalizedQuery, Math.max(limit * 2, 10)) as RawToolRecord[];
+    if (!raw || raw.length === 0) {
+      return [];
+    }
+
+    const qTokens = this.tokenize(normalizedQuery);
+
+    const scored = raw.map((entry, index) => {
+      const name = (entry.tool_name ?? entry.toolName ?? '').toString();
+      const server = (entry.server_name ?? entry.serverName ?? '').toString();
+      const category = (entry.category ?? '').toString();
+      const description = (entry.description ?? '').toString();
+      const keywords = this.toStringArray(entry.keywords ?? '[]');
+      const useCases = this.toStringArray(entry.use_cases ?? entry.useCases ?? '[]');
+      const createdAt = entry.created_at ?? entry.createdAt;
+
+      const haystack = this.tokenize([name, description, ...keywords, ...useCases].join(' '));
+
+      let score = 0;
+      for (const token of qTokens) {
+        if (!token) continue;
+        if (name.toLowerCase().includes(token)) score += 6;
+        if (server.toLowerCase().includes(token)) score += 3;
+        if (category.toLowerCase().includes(token)) score += 2;
+        if (description.toLowerCase().includes(token)) score += 2.5;
+        if (keywords.some((kw) => kw.toLowerCase().includes(token))) score += 1.75;
+        if (useCases.some((kw) => kw.toLowerCase().includes(token))) score += 1.5;
+        if (haystack.filter((w) => w === token).length > 1) {
+          score += 0.5;
+        }
+      }
+
+      // Bonus for early DB matches to stabilise ordering
+      score += Math.max(0, 3 - index * 0.25);
+
+      return {
+        name,
+        server,
+        category,
+        description,
+        keywords,
+        useCases,
+        score,
+        createdAt,
+      };
+    });
+
+    const maxScore = Math.max(...scored.map((s) => s.score));
+    const minScore = Math.min(...scored.map((s) => s.score));
+    const scoreRange = Math.max(1e-6, maxScore - minScore);
+
+    const ranked = scored
+      .map((entry) => ({
+        ...entry,
+        score: Number(((entry.score - minScore) / scoreRange).toFixed(4)),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map((entry, idx) => ({
+        name: entry.name,
+        server: entry.server,
+        category: entry.category,
+        description: entry.description,
+        keywords: entry.keywords,
+        useCases: entry.useCases,
+        score: entry.score,
+        rank: idx + 1,
+        lastIndexedAt: entry.createdAt ? new Date(entry.createdAt).toISOString() : undefined,
+      }));
+
+    return ranked;
   }
 
   /**
@@ -89,6 +181,39 @@ export class ToolIndexer {
    */
   getToolsByServer(serverName: string): any[] {
     return this.db.getToolsByServer(serverName);
+  }
+
+  private toStringArray(value: string | string[]): string[] {
+    if (Array.isArray(value)) {
+      return value.map((item) => item.toString());
+    }
+
+    if (!value) return [];
+
+    const trimmed = value.toString().trim();
+    if (!trimmed) return [];
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => item?.toString?.() ?? '').filter(Boolean);
+      }
+    } catch (error) {
+      // Not JSON, fall back to comma separated parsing
+    }
+
+    return trimmed
+      .split(/[,\n]/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+
+  private tokenize(text: string): string[] {
+    return text
+      .toLowerCase()
+      .split(/[^a-z0-9+]+/i)
+      .map((token) => token.trim())
+      .filter(Boolean);
   }
 }
 

--- a/packages/thinking-tools-mcp/src/tools/context_query.ts
+++ b/packages/thinking-tools-mcp/src/tools/context_query.ts
@@ -5,6 +5,8 @@
 
 import type { ServerContext } from '../lib/context.js';
 
+const MAX_RESULTS = 50;
+
 export const contextQueryDescriptor = {
   name: 'context_query',
   description: 'Query indexed code semantically. Returns ranked search results.',
@@ -12,26 +14,192 @@ export const contextQueryDescriptor = {
     type: 'object',
     properties: {
       query: { type: 'string', description: 'Search query' },
-      top_k: { type: 'number', description: 'Number of results to return (default: 12)' },
+      top_k: { type: 'number', description: 'Number of results to return (default: 12, max: 50)' },
     },
     required: ['query'],
   },
 };
 
 export async function contextQueryTool(args: any, ctx: ServerContext) {
-  const hits = await ctx.ctx.search(args.query, args.top_k || 12);
-  if (!hits || !Array.isArray(hits)) {
-    return { hits: [], error: 'Search returned no results' };
+  const query = typeof args?.query === 'string' ? args.query.trim() : '';
+  if (!query) {
+    return { hits: [], error: 'Query is required' };
   }
+
+  const topK = clamp(Math.floor(Number(args?.top_k) || 12), 1, MAX_RESULTS);
+  let hits: any[] = [];
+  let usedFallback = false;
+
+  try {
+    const primary = await ctx.ctx.search(query, topK);
+    if (Array.isArray(primary)) {
+      hits = primary;
+    }
+  } catch (error) {
+    console.error('[ThinkingTools] context_query primary search failed:', (error as Error)?.message ?? error);
+  }
+
+  if (!hits.length) {
+    try {
+      const blended = await ctx.blendedSearch(query, topK);
+      if (Array.isArray(blended) && blended.length) {
+        hits = blended;
+        usedFallback = true;
+      }
+    } catch (error) {
+      console.error('[ThinkingTools] context_query blended search failed:', (error as Error)?.message ?? error);
+    }
+  }
+
+  if (!hits.length) {
+    return {
+      query,
+      hits: [],
+      rankingMode: ctx.rankingMode(),
+      error: 'Search returned no results',
+    };
+  }
+
+  const normalized = normalizeHits(hits, query);
+
   return {
-    hits: hits.map((h: any) => ({
-      score: h.score,
-      path: h.uri,
-      title: h.title,
-      snippet: h.snippet,
-      method: h._method,
-      provider: h._provider
-    }))
+    query,
+    rankingMode: ctx.rankingMode(),
+    usedFallback,
+    totalResults: normalized.length,
+    summary: buildSummary(normalized, query, usedFallback, ctx.rankingMode()),
+    hits: normalized,
   };
+}
+
+function normalizeHits(rawHits: any[], query: string) {
+  const tokens = tokenize(query);
+  const rawScores = rawHits.map((hit) => toNumber(hit?.score));
+  const normalizedScores = normalizeScores(rawScores, rawHits.length);
+
+  return rawHits.map((hit, index) => {
+    const score = normalizedScores[index];
+    const path = hit?.uri ?? hit?.path ?? hit?.file ?? '';
+    const title = hit?.title ?? (path ? extractFilename(path) : 'Context match');
+    const snippet = buildSnippet(hit?.snippet ?? hit?.text ?? '', tokens);
+    const provider = hit?._provider ?? hit?.provider ?? hit?.meta?.type ?? 'local';
+    const method = hit?._method ?? hit?.method ?? hit?.meta?.method;
+
+    return {
+      rank: index + 1,
+      score,
+      path,
+      title,
+      snippet,
+      provider,
+      method,
+      highlights: tokens.filter((token) => snippet.toLowerCase().includes(token)).slice(0, 6),
+      metadata: {
+        source: provider,
+        method,
+        length: snippet.length,
+        rawScore: toNumber(hit?.score),
+        extra: hit?.meta ?? null,
+      },
+    };
+  });
+}
+
+function normalizeScores(scores: Array<number | null>, total: number): number[] {
+  const valid = scores.filter((score): score is number => typeof score === 'number' && Number.isFinite(score));
+  if (!valid.length) {
+    return scores.map((_, index) => Number(clamp(1 - index / Math.max(1, total), 0.05, 1).toFixed(4)));
+  }
+
+  const max = Math.max(...valid);
+  const min = Math.min(...valid);
+
+  if (Math.abs(max - min) < 1e-6) {
+    return scores.map((score, index) => {
+      if (typeof score === 'number' && Number.isFinite(score)) {
+        return Number((score > 0 ? 1 : 0).toFixed(4));
+      }
+      return Number(clamp(1 - index / Math.max(1, total), 0.05, 1).toFixed(4));
+    });
+  }
+
+  return scores.map((score, index) => {
+    if (typeof score === 'number' && Number.isFinite(score)) {
+      const normalized = (score - min) / (max - min);
+      return Number(clamp(normalized, 0, 1).toFixed(4));
+    }
+    return Number(clamp(1 - index / Math.max(1, total), 0.05, 1).toFixed(4));
+  });
+}
+
+function buildSnippet(raw: string, tokens: string[]): string {
+  const cleaned = raw
+    .toString()
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) return '';
+
+  if (cleaned.length <= 600) {
+    return cleaned;
+  }
+
+  const lower = cleaned.toLowerCase();
+  let bestIndex = 0;
+  let bestScore = -1;
+
+  for (const token of tokens) {
+    const idx = lower.indexOf(token);
+    if (idx >= 0 && (bestScore === -1 || idx < bestIndex)) {
+      bestIndex = idx;
+      bestScore = token.length;
+    }
+  }
+
+  const start = Math.max(0, bestIndex - 120);
+  const end = Math.min(cleaned.length, start + 600);
+  const snippet = cleaned.slice(start, end);
+  return start > 0 ? `…${snippet}` : snippet;
+}
+
+function buildSummary(hits: any[], query: string, usedFallback: boolean, rankingMode: string) {
+  if (!hits.length) {
+    return `No matches found for "${query}".`;
+  }
+
+  const top = hits[0];
+  const providers = Array.from(new Set(hits.map((hit) => hit.provider))).slice(0, 3);
+  const origin = usedFallback ? 'blended search (local + imported evidence)' : 'local context index';
+
+  return `Found ${hits.length} relevant chunk${hits.length === 1 ? '' : 's'} for "${query}" via ${origin} ` +
+    `(ranking: ${rankingMode}). Top match: ${top.title || top.path || 'untitled'} (${providers.join(', ')}).`;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function extractFilename(path: string): string {
+  const parts = path.split(/[/\\]/);
+  return parts[parts.length - 1] || path;
 }
 

--- a/packages/thinking-tools-mcp/src/tools/decision-matrix.ts
+++ b/packages/thinking-tools-mcp/src/tools/decision-matrix.ts
@@ -27,170 +27,145 @@ export interface DecisionMatrixOutput {
   reasoning: string;
 }
 
+type CriterionSignals = {
+  positive: string[];
+  negative: string[];
+  synonyms: string[];
+  emphasize?: string[];
+};
+
+const DEFAULT_CRITERIA = [
+  'Cost',
+  'Performance',
+  'Maintainability',
+  'Scalability',
+  'Time to Implement',
+  'Team Expertise',
+  'Risk',
+];
+
+const CRITERION_SIGNALS: Record<string, CriterionSignals> = {
+  Cost: {
+    positive: ['free', 'open source', 'affordable', 'low cost', 'budget friendly', 'saves'],
+    negative: ['expensive', 'costly', 'premium', 'high cost', 'pricey'],
+    synonyms: ['cost', 'price', 'budget', 'spend'],
+    emphasize: ['mvp', 'startup', 'bootstrap'],
+  },
+  Performance: {
+    positive: ['fast', 'optimized', 'low latency', 'high throughput', 'performant', 'cache', 'cdn'],
+    negative: ['slow', 'laggy', 'high latency', 'bottleneck', 'throttled'],
+    synonyms: ['performance', 'speed', 'latency', 'throughput'],
+    emphasize: ['production', 'realtime', 'high traffic'],
+  },
+  Maintainability: {
+    positive: ['simple', 'minimal', 'well documented', 'standard', 'popular', 'clean', 'modular'],
+    negative: ['complex', 'custom', 'spaghetti', 'legacy', 'hard to maintain', 'fragile'],
+    synonyms: ['maintainability', 'maintenance', 'cleanliness', 'modularity'],
+  },
+  Scalability: {
+    positive: ['scalable', 'distributed', 'cloud', 'serverless', 'autoscale', 'horizontal', 'replication'],
+    negative: ['monolith', 'single node', 'single server', 'not scalable', 'manual scaling', 'bottleneck'],
+    synonyms: ['scale', 'scalability', 'capacity', 'throughput'],
+    emphasize: ['enterprise', 'global', 'multi-region'],
+  },
+  'Time to Implement': {
+    positive: ['quick', 'fast to implement', 'ready-made', 'managed', 'saas', 'turnkey', 'plug and play'],
+    negative: ['custom build', 'long ramp', 'months', 'slow rollout', 'complex setup', 'weeks of work'],
+    synonyms: ['time to implement', 'implementation time', 'build time', 'delivery'],
+    emphasize: ['deadline', 'launch date', 'urgent', 'crunch'],
+  },
+  'Team Expertise': {
+    positive: ['familiar', 'known', 'expert', 'skillset', 'experienced', 'existing team'],
+    negative: ['learning curve', 'unfamiliar', 'no experience', 'new tech', 'training required'],
+    synonyms: ['expertise', 'skills', 'learning curve', 'team experience'],
+  },
+  Risk: {
+    positive: ['low risk', 'proven', 'stable', 'battle-tested', 'mature', 'reliable'],
+    negative: ['risky', 'unstable', 'experimental', 'beta', 'unknown', 'untested', 'downtime'],
+    synonyms: ['risk', 'uncertainty', 'safety', 'reliability'],
+  },
+};
+
+const POSITIVE_SENTIMENT = ['best', 'ideal', 'preferred', 'recommended', 'strong'];
+const NEGATIVE_SENTIMENT = ['worst', 'avoid', 'poor', 'weak', 'concern'];
+
 export function decisionMatrix(input: DecisionMatrixInput): DecisionMatrixOutput {
   const { options, criteria = [], context = '' } = input;
-  const combined = `${options.join(' ')} ${criteria.join(' ')} ${context}`.toLowerCase();
-  
-  // Auto-detect criteria if not provided
-  const detectedCriteria = criteria.length > 0 ? criteria : [
-    'Cost',
-    'Performance',
-    'Maintainability',
-    'Scalability',
-    'Time to Implement',
-    'Team Expertise',
-    'Risk'
-  ];
-  
-  // Auto-detect weights based on context
-  const weights: { [key: string]: number } = {};
-  
-  if (combined.includes('startup') || combined.includes('mvp')) {
-    weights['Cost'] = 0.25;
-    weights['Time to Implement'] = 0.25;
-    weights['Performance'] = 0.10;
-    weights['Maintainability'] = 0.15;
-    weights['Scalability'] = 0.10;
-    weights['Team Expertise'] = 0.10;
-    weights['Risk'] = 0.05;
-  } else if (combined.includes('enterprise') || combined.includes('production')) {
-    weights['Cost'] = 0.10;
-    weights['Time to Implement'] = 0.10;
-    weights['Performance'] = 0.20;
-    weights['Maintainability'] = 0.20;
-    weights['Scalability'] = 0.20;
-    weights['Team Expertise'] = 0.10;
-    weights['Risk'] = 0.10;
-  } else {
-    // Balanced weights
-    const equalWeight = 1.0 / detectedCriteria.length;
-    detectedCriteria.forEach(c => weights[c] = equalWeight);
+  if (!options || !options.length) {
+    throw new Error('decision_matrix requires at least one option to evaluate');
   }
-  
-  const matrix: Array<{
-    option: string;
-    scores: Array<{ criterion: string; score: number; weight: number; weightedScore: number }>;
-    totalScore: number;
-    rank: number;
-  }> = [];
-  
-  const tradeoffs: Array<{ option: string; strengths: string[]; weaknesses: string[] }> = [];
-  
-  // Score each option
-  options.forEach(option => {
-    const optionLower = option.toLowerCase();
-    const scores: Array<{ criterion: string; score: number; weight: number; weightedScore: number }> = [];
-    
-    detectedCriteria.forEach(criterion => {
-      let score = 50; // Start neutral
-      const weight = weights[criterion] || (1.0 / detectedCriteria.length);
-      
-      // Score based on option characteristics
-      if (criterion === 'Cost') {
-        if (optionLower.includes('free') || optionLower.includes('open source')) score = 90;
-        else if (optionLower.includes('cheap') || optionLower.includes('low cost')) score = 80;
-        else if (optionLower.includes('expensive') || optionLower.includes('enterprise')) score = 30;
-        else if (optionLower.includes('cloud') || optionLower.includes('saas')) score = 60;
-      }
-      
-      if (criterion === 'Performance') {
-        if (optionLower.includes('fast') || optionLower.includes('optimized')) score = 85;
-        else if (optionLower.includes('slow') || optionLower.includes('legacy')) score = 40;
-        else if (optionLower.includes('cache') || optionLower.includes('cdn')) score = 90;
-      }
-      
-      if (criterion === 'Maintainability') {
-        if (optionLower.includes('simple') || optionLower.includes('minimal')) score = 85;
-        else if (optionLower.includes('complex') || optionLower.includes('custom')) score = 40;
-        else if (optionLower.includes('standard') || optionLower.includes('popular')) score = 75;
-      }
-      
-      if (criterion === 'Scalability') {
-        if (optionLower.includes('cloud') || optionLower.includes('distributed')) score = 85;
-        else if (optionLower.includes('monolith') || optionLower.includes('single')) score = 50;
-        else if (optionLower.includes('microservice') || optionLower.includes('serverless')) score = 90;
-      }
-      
-      if (criterion === 'Time to Implement') {
-        if (optionLower.includes('quick') || optionLower.includes('ready')) score = 85;
-        else if (optionLower.includes('custom') || optionLower.includes('build')) score = 40;
-        else if (optionLower.includes('saas') || optionLower.includes('managed')) score = 90;
-      }
-      
-      if (criterion === 'Team Expertise') {
-        if (optionLower.includes('familiar') || optionLower.includes('known')) score = 85;
-        else if (optionLower.includes('new') || optionLower.includes('learning')) score = 40;
-        else if (optionLower.includes('popular') || optionLower.includes('standard')) score = 70;
-      }
-      
-      if (criterion === 'Risk') {
-        if (optionLower.includes('proven') || optionLower.includes('stable')) score = 85;
-        else if (optionLower.includes('experimental') || optionLower.includes('beta')) score = 30;
-        else if (optionLower.includes('new') || optionLower.includes('cutting edge')) score = 40;
-      }
-      
-      scores.push({
+
+  const detectedCriteria = (criteria.length ? criteria : DEFAULT_CRITERIA).map(normalizeLabel);
+  const contextSegments = buildOptionContext(options, context);
+  const weights = deriveWeights(detectedCriteria, context);
+
+  const matrix = options.map((option) => {
+    const optionText = `${option}\n${contextSegments.get(option) ?? context}`.toLowerCase();
+    const scores = detectedCriteria.map((criterion) => {
+      const weight = weights[criterion] ?? 1 / detectedCriteria.length;
+      const score = scoreOptionAgainstCriterion(option, optionText, criterion, contextSegments.get(option) ?? context);
+      return {
         criterion,
         score,
         weight,
-        weightedScore: score * weight
-      });
+        weightedScore: score * weight,
+      };
     });
-    
-    const totalScore = scores.reduce((sum, s) => sum + s.weightedScore, 0);
-    
-    matrix.push({
+
+    return {
       option,
       scores,
-      totalScore,
-      rank: 0 // Will be set after sorting
-    });
-    
-    // Identify strengths and weaknesses
-    const strengths: string[] = [];
-    const weaknesses: string[] = [];
-    
-    scores.forEach(s => {
-      if (s.score >= 80) {
-        strengths.push(`${s.criterion}: ${s.score}/100`);
-      } else if (s.score <= 40) {
-        weaknesses.push(`${s.criterion}: ${s.score}/100`);
-      }
-    });
-    
-    tradeoffs.push({
-      option,
-      strengths,
-      weaknesses
-    });
+      totalScore: scores.reduce((sum, entry) => sum + entry.weightedScore, 0),
+      rank: 0,
+    };
   });
-  
-  // Sort by total score and assign ranks
+
   matrix.sort((a, b) => b.totalScore - a.totalScore);
-  matrix.forEach((item, index) => {
-    item.rank = index + 1;
+  matrix.forEach((entry, idx) => {
+    entry.rank = idx + 1;
   });
-  
-  // Generate recommendation
+
+  const tradeoffs = matrix.map((entry) => {
+    const strengths = entry.scores
+      .filter((score) => score.score >= 75)
+      .sort((a, b) => b.weightedScore - a.weightedScore)
+      .map((score) => `${score.criterion}: ${score.score.toFixed(0)}/100 (weight ${(score.weight * 100).toFixed(0)}%)`);
+
+    const weaknesses = entry.scores
+      .filter((score) => score.score <= 45)
+      .sort((a, b) => a.score - b.score)
+      .map((score) => `${score.criterion}: ${score.score.toFixed(0)}/100 (needs attention)`);
+
+    return { option: entry.option, strengths, weaknesses };
+  });
+
   const winner = matrix[0];
   const runnerUp = matrix[1];
-  
-  let recommendation = `Recommended: ${winner.option} (score: ${winner.totalScore.toFixed(1)})`;
-  
-  if (runnerUp && Math.abs(winner.totalScore - runnerUp.totalScore) < 5) {
-    recommendation += ` - CLOSE CALL with ${runnerUp.option} (score: ${runnerUp.totalScore.toFixed(1)}). Consider both options carefully.`;
-  } else if (runnerUp) {
-    recommendation += ` - Clear winner over ${runnerUp.option} (score: ${runnerUp.totalScore.toFixed(1)})`;
+  const winnerDrivers = [...winner.scores]
+    .sort((a, b) => b.weightedScore - a.weightedScore)
+    .slice(0, Math.min(3, winner.scores.length))
+    .map((score) => `${score.criterion} (${(score.weight * 100).toFixed(0)}% weight)`);
+
+  let recommendation = `Recommended: ${winner.option} — ${winner.totalScore.toFixed(1)}/100 driven by ${winnerDrivers.join(', ')}`;
+
+  if (runnerUp) {
+    const gap = winner.totalScore - runnerUp.totalScore;
+    if (gap < 5) {
+      recommendation += `. Close call with ${runnerUp.option} (${runnerUp.totalScore.toFixed(1)}/100); validate with qualitative factors.`;
+    } else {
+      recommendation += `. Outperforms ${runnerUp.option} by ${gap.toFixed(1)} points.`;
+    }
   }
-  
-  const confidence = winner.totalScore >= 70 ? 80 : winner.totalScore >= 60 ? 65 : 50;
+
+  const confidence = computeConfidence(matrix, weights);
+  const reasoning = buildReasoning(matrix, detectedCriteria.length, weights);
 
   return {
     matrix,
     recommendation,
     tradeoffs,
     confidence,
-    reasoning: `Evaluated ${options.length} options across ${detectedCriteria.length} criteria with weighted scoring. Top option scored ${winner.totalScore.toFixed(1)}/100.`
+    reasoning,
   };
 }
 
@@ -201,4 +176,293 @@ export const decisionMatrixEnhanced = withContext(
   decisionMatrix,
   (input) => `${input.options.join(' ')} ${input.context || ''}`.slice(0, 200)
 );
+
+function normalizeLabel(label: string): string {
+  if (!label) return '';
+  return label
+    .toString()
+    .trim()
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/(^|\s)([a-z])/g, (_, space, char) => `${space}${char.toUpperCase()}`);
+}
+
+function buildOptionContext(options: string[], context: string): Map<string, string> {
+  const segments = new Map<string, string>();
+  if (!context?.trim()) {
+    options.forEach((option) => segments.set(option, option));
+    return segments;
+  }
+
+  const paragraphs = context.split(/\n\s*\n/);
+  const lines = context.split(/\r?\n/);
+
+  options.forEach((option) => {
+    const normalized = option.toLowerCase();
+    const matchingParagraphs = paragraphs.filter((paragraph) => paragraph.toLowerCase().includes(normalized));
+
+    if (matchingParagraphs.length) {
+      segments.set(option, matchingParagraphs.join('\n\n'));
+      return;
+    }
+
+    const alias = deriveAliases(option);
+    const matchingLines = lines.filter((line) => {
+      const lower = line.toLowerCase();
+      return alias.some((candidate) => lower.startsWith(candidate) || lower.includes(candidate));
+    });
+
+    if (matchingLines.length) {
+      segments.set(option, matchingLines.join('\n'));
+      return;
+    }
+
+    segments.set(option, context);
+  });
+
+  return segments;
+}
+
+function deriveAliases(option: string): string[] {
+  const lower = option.toLowerCase().trim();
+  const aliases = new Set<string>([lower]);
+
+  if (/option\s+[a-z]/.test(lower)) {
+    aliases.add(lower.replace(/[^a-z]/g, ' ').trim());
+    aliases.add(lower.replace(/^option\s+/, '').trim());
+  }
+
+  const parts = lower.split(/[^a-z0-9]+/).filter(Boolean);
+  if (parts.length) {
+    aliases.add(parts.join(' '));
+  }
+
+  return Array.from(aliases).filter(Boolean);
+}
+
+function deriveWeights(criteria: string[], context: string): Record<string, number> {
+  const combined = `${criteria.join(' ')} ${context}`.toLowerCase();
+  const baseWeights = new Map<string, number>();
+
+  const startup = combined.includes('startup') || combined.includes('mvp') || combined.includes('bootstrap');
+  const enterprise = combined.includes('enterprise') || combined.includes('production') || combined.includes('compliance');
+
+  criteria.forEach((criterion) => {
+    const signals = CRITERION_SIGNALS[criterion] ?? createSignalsForCustomCriterion(criterion);
+    let weight = 1;
+
+    if (startup && signals.emphasize?.some((word) => combined.includes(word))) {
+      weight += 0.6;
+    }
+
+    if (enterprise && signals.emphasize?.some((word) => combined.includes(word))) {
+      weight += 0.6;
+    }
+
+    if (combined.includes(criterion.toLowerCase())) {
+      weight += 0.4;
+    }
+
+    const signalHits = signals.synonyms.filter((syn) => combined.includes(syn));
+    weight += signalHits.length * 0.2;
+
+    baseWeights.set(criterion, weight);
+  });
+
+  const total = Array.from(baseWeights.values()).reduce((sum, weight) => sum + weight, 0);
+  if (total <= 0) {
+    const equal = 1 / Math.max(1, criteria.length);
+    return Object.fromEntries(criteria.map((criterion) => [criterion, equal]));
+  }
+
+  return Object.fromEntries(
+    Array.from(baseWeights.entries()).map(([criterion, weight]) => [criterion, weight / total])
+  );
+}
+
+function scoreOptionAgainstCriterion(
+  option: string,
+  optionText: string,
+  criterion: string,
+  contextSegment: string
+): number {
+  const signals = CRITERION_SIGNALS[criterion] ?? createSignalsForCustomCriterion(criterion);
+  let score = 55;
+
+  const optionLower = option.toLowerCase();
+  score = applyHeuristics(optionLower, criterion, score);
+
+  const combinedText = `${optionText}\n${contextSegment}`.toLowerCase();
+  const numeric = extractNumericSignal(combinedText, signals.synonyms);
+  if (numeric !== null) {
+    score = blend(score, numeric, 0.65);
+  }
+
+  for (const positive of signals.positive) {
+    if (combinedText.includes(positive)) {
+      score += 6;
+    }
+  }
+
+  for (const negative of signals.negative) {
+    if (combinedText.includes(negative)) {
+      score -= 6;
+    }
+  }
+
+  for (const synonym of signals.synonyms) {
+    const highPattern = new RegExp(`(high|strong|great)\s+${escapeRegExp(synonym)}`);
+    const lowPattern = new RegExp(`(low|weak|poor)\s+${escapeRegExp(synonym)}`);
+    if (highPattern.test(combinedText)) score += 7;
+    if (lowPattern.test(combinedText)) score -= 7;
+  }
+
+  for (const positive of POSITIVE_SENTIMENT) {
+    if (combinedText.includes(positive)) {
+      score += 3;
+    }
+  }
+
+  for (const negative of NEGATIVE_SENTIMENT) {
+    if (combinedText.includes(negative)) {
+      score -= 3;
+    }
+  }
+
+  if (combinedText.includes('better than') && combinedText.includes(optionLower)) {
+    score += 4;
+  }
+
+  if (combinedText.includes('worse than') && combinedText.includes(optionLower)) {
+    score -= 4;
+  }
+
+  return clampScore(score);
+}
+
+function applyHeuristics(optionLower: string, criterion: string, startingScore: number): number {
+  let score = startingScore;
+
+  if (criterion === 'Cost') {
+    if (optionLower.includes('free') || optionLower.includes('open source')) score += 25;
+    else if (optionLower.includes('cheap') || optionLower.includes('low cost')) score += 15;
+    else if (optionLower.includes('expensive') || optionLower.includes('enterprise')) score -= 20;
+    else if (optionLower.includes('cloud') || optionLower.includes('saas')) score += 5;
+  }
+
+  if (criterion === 'Performance') {
+    if (optionLower.includes('fast') || optionLower.includes('optimized')) score += 20;
+    else if (optionLower.includes('slow') || optionLower.includes('legacy')) score -= 15;
+    else if (optionLower.includes('cache') || optionLower.includes('cdn')) score += 22;
+  }
+
+  if (criterion === 'Maintainability') {
+    if (optionLower.includes('simple') || optionLower.includes('minimal')) score += 18;
+    else if (optionLower.includes('complex') || optionLower.includes('custom')) score -= 18;
+    else if (optionLower.includes('standard') || optionLower.includes('popular')) score += 12;
+  }
+
+  if (criterion === 'Scalability') {
+    if (optionLower.includes('cloud') || optionLower.includes('distributed')) score += 18;
+    else if (optionLower.includes('monolith') || optionLower.includes('single')) score -= 10;
+    else if (optionLower.includes('microservice') || optionLower.includes('serverless')) score += 22;
+  }
+
+  if (criterion === 'Time to Implement') {
+    if (optionLower.includes('quick') || optionLower.includes('ready')) score += 18;
+    else if (optionLower.includes('custom') || optionLower.includes('build')) score -= 15;
+    else if (optionLower.includes('saas') || optionLower.includes('managed')) score += 22;
+  }
+
+  if (criterion === 'Team Expertise') {
+    if (optionLower.includes('familiar') || optionLower.includes('known')) score += 18;
+    else if (optionLower.includes('new') || optionLower.includes('learning')) score -= 18;
+    else if (optionLower.includes('popular') || optionLower.includes('standard')) score += 10;
+  }
+
+  if (criterion === 'Risk') {
+    if (optionLower.includes('proven') || optionLower.includes('stable')) score += 18;
+    else if (optionLower.includes('experimental') || optionLower.includes('beta')) score -= 20;
+    else if (optionLower.includes('new') || optionLower.includes('cutting edge')) score -= 10;
+  }
+
+  return score;
+}
+
+function extractNumericSignal(text: string, synonyms: string[]): number | null {
+  for (const synonym of synonyms) {
+    const pattern = new RegExp(`${escapeRegExp(synonym)}[^0-9]{0,16}(\d{1,3}(?:\.\d{1,2})?)\s*(?:/\s*(\d{1,3})|%)?`, 'i');
+    const match = text.match(pattern);
+    if (match) {
+      const value = parseFloat(match[1]);
+      const denominator = match[2] ? parseFloat(match[2]) : match[0].includes('%') ? 100 : undefined;
+      if (denominator && denominator > 0) {
+        return clampScore((value / denominator) * 100);
+      }
+      if (!denominator) {
+        if (value <= 1) return clampScore(value * 100);
+        if (value <= 5) return clampScore((value / 5) * 100);
+        if (value <= 10) return clampScore((value / 10) * 100);
+        return clampScore(value);
+      }
+    }
+  }
+  return null;
+}
+
+function blend(base: number, value: number, weight: number): number {
+  return base * (1 - weight) + value * weight;
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, score));
+}
+
+function computeConfidence(matrix: Array<{ totalScore: number }>, weights: Record<string, number>): number {
+  if (!matrix.length) return 50;
+  const scores = matrix.map((entry) => entry.totalScore);
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  const spread = max - min;
+  const weightConcentration = Math.max(...Object.values(weights));
+
+  let confidence = 60 + spread * 0.4 + (weightConcentration * 100 - 50) * 0.25;
+  if (matrix.length === 1) {
+    confidence = 65 + max * 0.2;
+  }
+
+  return Math.max(45, Math.min(96, confidence));
+}
+
+function buildReasoning(
+  matrix: Array<{ option: string; totalScore: number; scores: Array<{ criterion: string; score: number; weight: number }> }>,
+  criteriaCount: number,
+  weights: Record<string, number>
+): string {
+  const winner = matrix[0];
+  const runnerUp = matrix[1];
+  const weightLeaders = Object.entries(weights)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, Math.min(3, Object.keys(weights).length))
+    .map(([criterion, weight]) => `${criterion} (${(weight * 100).toFixed(0)}%)`)
+    .join(', ');
+
+  const gap = runnerUp ? (winner.totalScore - runnerUp.totalScore).toFixed(1) : 'n/a';
+  return `Evaluated ${matrix.length} option${matrix.length === 1 ? '' : 's'} across ${criteriaCount} criteria. ` +
+    `Highest weighted factors: ${weightLeaders}. Score gap vs runner-up: ${gap}.`;
+}
+
+function createSignalsForCustomCriterion(label: string): CriterionSignals {
+  const normalized = normalizeLabel(label);
+  const tokens = normalized.toLowerCase().split(/\s+/).filter(Boolean);
+  return {
+    positive: ['high', 'strong', 'robust', 'improves', 'benefit'],
+    negative: ['low', 'weak', 'issue', 'problem', 'gap'],
+    synonyms: tokens.length ? tokens : [normalized.toLowerCase()],
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 


### PR DESCRIPTION
## Summary
- ensure the credit optimizer server waits for its tool index to finish initializing before servicing discovery requests
- normalize discovery results with relevance scoring, ranks, and parsed metadata for richer tool exploration
- enhance thinking tools context queries and decision matrix scoring with blended fallbacks, contextual heuristics, and clearer recommendations

## Testing
- npm run build --workspaces --if-present

------
https://chatgpt.com/codex/tasks/task_b_690a8c0789c0832bbe3095a2dc693fcd