### PR TITLE
Improve context engine defaults and live index upkeep

### DIFF
--- a/packages/thinking-tools-mcp/package.json
+++ b/packages/thinking-tools-mcp/package.json
@@ -63,6 +63,12 @@
     "slash": "^5.1.0",
     "slugify": "^1.6.6",
     "string-strip-html": "^13.5.0",
+    "tree-sitter": "^0.22.6",
+    "tree-sitter-cpp": "^0.20.0",
+    "tree-sitter-go": "^0.20.0",
+    "tree-sitter-java": "^0.20.0",
+    "tree-sitter-python": "^0.20.4",
+    "tree-sitter-rust": "^0.20.4",
     "undici": "^6.22.0",
     "unified": "^11.0.5"
   },

--- a/packages/thinking-tools-mcp/src/context/config.ts
+++ b/packages/thinking-tools-mcp/src/context/config.ts
@@ -1,0 +1,90 @@
+let defaultsApplied = false;
+
+type Provider = 'openai' | 'voyage' | 'ollama';
+
+const STATIC_DEFAULTS: Record<string, string> = {
+  RCE_LAZY_INDEX: '1',
+  RCE_MAX_DISK_MB: '512',
+  RCE_COMPRESSION: 'auto',
+  RCE_COMPRESSION_THRESHOLD: '4096',
+  RCE_INDEX_TTL_MINUTES: '20',
+  RCE_MAX_CHANGED_PER_RUN: '800',
+  RCE_QUICK_MAX_FILES: '400',
+  CTX_AUTO_WATCH: '1',
+  CTX_FALLBACK_EMBED_DIMS: '384',
+  OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+};
+
+function normalizeProvider(value: string | undefined): Provider | undefined {
+  if (!value) return undefined;
+  const lower = value.toLowerCase();
+  if (lower === 'openai' || lower === 'voyage' || lower === 'ollama') {
+    return lower;
+  }
+  return undefined;
+}
+
+function detectEmbeddingDefaults(explicit?: Provider): { provider: Provider; model: string } {
+  const chosen = explicit
+    ?? (process.env.OPENAI_API_KEY ? 'openai'
+      : (process.env.VOYAGE_API_KEY || process.env.ANTHROPIC_API_KEY) ? 'voyage'
+        : 'ollama');
+
+  if (chosen === 'openai') {
+    const model = process.env.OPENAI_EMBED_MODEL || 'text-embedding-3-small';
+    return { provider: 'openai', model };
+  }
+
+  if (chosen === 'voyage') {
+    const model = process.env.VOYAGE_EMBED_MODEL || 'voyage-code-2';
+    return { provider: 'voyage', model };
+  }
+
+  const model = process.env.OLLAMA_EMBED_MODEL || 'nomic-embed-text';
+  return { provider: 'ollama', model };
+}
+
+/**
+ * Apply zero-config defaults for the context engine.
+ * Prefers OpenAI → Voyage → Ollama automatically and fills in sane limits.
+ */
+export function applyContextDefaults(): void {
+  if (defaultsApplied) return;
+  defaultsApplied = true;
+
+  const explicitProvider = normalizeProvider(
+    process.env.CTX_EMBED_PROVIDER ?? process.env.EMBED_PROVIDER
+  );
+  const { provider, model } = detectEmbeddingDefaults(explicitProvider);
+
+  if (!process.env.CTX_EMBED_PROVIDER) {
+    process.env.CTX_EMBED_PROVIDER = provider;
+  }
+  if (!process.env.EMBED_PROVIDER) {
+    process.env.EMBED_PROVIDER = provider;
+  }
+
+  if (!process.env.RCE_EMBED_MODEL) {
+    process.env.RCE_EMBED_MODEL = model;
+  }
+  if (!process.env.EMBED_MODEL) {
+    process.env.EMBED_MODEL = model;
+  }
+
+  if (provider === 'openai' && !process.env.OPENAI_EMBED_MODEL) {
+    process.env.OPENAI_EMBED_MODEL = model;
+  }
+  if (provider === 'voyage' && !process.env.VOYAGE_EMBED_MODEL) {
+    process.env.VOYAGE_EMBED_MODEL = model;
+  }
+  if (provider === 'ollama' && !process.env.OLLAMA_EMBED_MODEL) {
+    process.env.OLLAMA_EMBED_MODEL = model;
+  }
+
+  for (const [key, value] of Object.entries(STATIC_DEFAULTS)) {
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+

--- a/packages/thinking-tools-mcp/src/context/graph.ts
+++ b/packages/thinking-tools-mcp/src/context/graph.ts
@@ -2,40 +2,132 @@ import fs from 'fs';
 import path from 'path';
 import fg from 'fast-glob';
 
-export function buildImportGraph(repoRoot = process.cwd()): Array<{ from: string; to: string }> {
-  const edges: Array<{ from: string; to: string }> = [];
-  
-  const scan = (p: string) => {
-    if (!/\.(ts|tsx|js|jsx)$/.test(p)) return;
-    
-    const t = fs.readFileSync(p, 'utf8');
-    const dir = path.dirname(p);
+type Edge = { from: string; to: string };
+
+const IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**', '**/.next/**', '**/.venv*/**'];
+const FILE_GLOB = ['**/*.{ts,tsx,js,jsx,py,go,java,rs,cpp,c,cc,cxx,h,hpp,hh}'];
+const EXTENSIONS = ['', '.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.java', '.rs', '.cpp', '.c', '.cc', '.cxx', '.mjs', '.mts', '.cts', '.h', '.hpp', '.hh'];
+
+function normalize(root: string, file: string): string {
+  const abs = path.isAbsolute(file) ? file : path.join(root, file);
+  return path.relative(root, abs).split(path.sep).join('/');
+}
+
+function resolveRelative(fromFile: string, spec: string): string | null {
+  const dir = path.dirname(fromFile);
+  const base = path.resolve(dir, spec);
+  const candidates = [base, ...EXTENSIONS.map(ext => base + ext), ...EXTENSIONS.map(ext => path.join(base, 'index' + ext)), path.join(base, '__init__.py')];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function resolvePythonRelative(fromFile: string, spec: string): string | null {
+  const match = spec.match(/^([.]+)(.*)$/);
+  if (!match) return null;
+  const depth = match[1].length;
+  const remainder = match[2].replace(/\./g, '/');
+  let dir = path.dirname(fromFile);
+  for (let i = 0; i < depth; i++) {
+    dir = path.dirname(dir);
+  }
+  const target = path.join(dir, remainder);
+  return resolveRelative(fromFile, path.relative(path.dirname(fromFile), target) || '.');
+}
+
+function addEdge(edges: Edge[], root: string, fromFile: string, target: string | null, spec: string) {
+  const from = normalize(root, fromFile);
+  const to = target ? normalize(root, target) : `external:${spec}`;
+  edges.push({ from, to });
+}
+
+function scanFile(root: string, file: string, edges: Edge[]) {
+  const ext = path.extname(file).toLowerCase();
+  const text = fs.readFileSync(file, 'utf8');
+  const dir = path.dirname(file);
+
+  if (['.ts', '.tsx', '.js', '.jsx', '.mjs', '.mts', '.cts'].includes(ext)) {
     const re = /import[^;]*from\s*['"]([^'"]+)['"]/g;
     let m;
-    
-    while ((m = re.exec(t))) {
-      let to = m[1];
-      if (to.startsWith('.')) {
-        try {
-          const rp = path.resolve(dir, to);
-          edges.push({ from: p, to: rp });
-        } catch {
-          // ignore resolution errors
-        }
+    while ((m = re.exec(text))) {
+      const spec = m[1];
+      if (spec.startsWith('.')) {
+        const resolved = resolveRelative(file, spec);
+        addEdge(edges, root, file, resolved, spec);
       }
     }
-  };
-  
-  const files = fg.sync(['**/*.{ts,tsx,js,jsx}'], {
-    cwd: repoRoot,
-    ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**'],
-    absolute: true
-  });
-  
-  for (const f of files) {
-    scan(f);
+  } else if (ext === '.py') {
+    const fromRe = /from\s+([.\w]+)\s+import\s+[\w*, ]+/g;
+    let m;
+    while ((m = fromRe.exec(text))) {
+      const spec = m[1];
+      const resolved = spec.startsWith('.') ? resolvePythonRelative(file, spec) : null;
+      addEdge(edges, root, file, resolved, spec);
+    }
+  } else if (ext === '.go') {
+    const importBlock = /import\s*(\(([^)]+)\)|"([^"]+)")/gm;
+    let m;
+    while ((m = importBlock.exec(text))) {
+      const block = m[2];
+      if (block) {
+        const lines = block.split(/\n/).map(l => l.trim()).filter(Boolean);
+        for (const line of lines) {
+          const match = line.match(/"([^"]+)"/);
+          if (match) {
+            addEdge(edges, root, file, null, match[1]);
+          }
+        }
+      } else if (m[3]) {
+        addEdge(edges, root, file, null, m[3]);
+      }
+    }
+  } else if (ext === '.rs') {
+    const useRe = /use\s+crate::([A-Za-z0-9_:]+)/g;
+    let m;
+    while ((m = useRe.exec(text))) {
+      const spec = m[1].replace(/::/g, '/');
+      const target = resolveRelative(file, `./${spec}.rs`);
+      addEdge(edges, root, file, target, spec);
+    }
+  } else if (['.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.hh'].includes(ext)) {
+    const includeRe = /#include\s+["<]([^">]+)[">]/g;
+    let m;
+    while ((m = includeRe.exec(text))) {
+      const spec = m[1];
+      if (spec.startsWith('.')) {
+        const resolved = path.resolve(dir, spec);
+        addEdge(edges, root, file, fs.existsSync(resolved) ? resolved : null, spec);
+      }
+    }
+  } else if (ext === '.java') {
+    const importRe = /import\s+([a-zA-Z0-9_.]+);/g;
+    let m;
+    while ((m = importRe.exec(text))) {
+      const spec = m[1];
+      addEdge(edges, root, file, null, spec);
+    }
   }
-  
+}
+
+export function buildImportGraph(repoRoot = process.cwd()): Array<{ from: string; to: string }> {
+  const edges: Edge[] = [];
+  const files = fg.sync(FILE_GLOB, {
+    cwd: repoRoot,
+    ignore: IGNORE,
+    absolute: true,
+  });
+
+  for (const file of files) {
+    try {
+      scanFile(repoRoot, file, edges);
+    } catch (error) {
+      console.warn(`[buildImportGraph] Failed to parse ${file}:`, (error as Error).message);
+    }
+  }
+
   return edges;
 }
 

--- a/packages/thinking-tools-mcp/src/context/languages.ts
+++ b/packages/thinking-tools-mcp/src/context/languages.ts
@@ -1,0 +1,260 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+type SyntaxNode = {
+  startIndex: number;
+  endIndex: number;
+  startPosition: { row: number; column: number };
+};
+
+type TreeSitterQuery = {
+  captures(node: SyntaxNode): Array<{ name: string; node: SyntaxNode }>;
+};
+
+type TreeSitterLanguage = {
+  query(source: string): TreeSitterQuery;
+};
+
+type TreeSitterParser = {
+  parse(source: string): { rootNode: SyntaxNode };
+  setLanguage(language: TreeSitterLanguage): void;
+};
+
+type SymbolRecordType = 'function' | 'class' | 'interface' | 'type' | 'const' | 'let' | 'var' | 'enum';
+
+export interface SymbolRecord {
+  name: string;
+  type: SymbolRecordType;
+  file: string;
+  line: number;
+  isPublic: boolean;
+  isExported: boolean;
+}
+
+type CaptureSpec = {
+  type: SymbolRecordType;
+  query: string;
+  capture?: string;
+  exported?: (name: string, node: SyntaxNode, source: string) => boolean;
+  public?: (name: string, node: SyntaxNode, source: string) => boolean;
+};
+
+type LanguageConfig = {
+  extensions: string[];
+  loader: () => Promise<any>;
+  captures: CaptureSpec[];
+  fallback?: (filePath: string, repoRoot: string, source: string) => SymbolRecord[];
+};
+
+type RuntimeCapture = CaptureSpec & { compiled: TreeSitterQuery; capture: string };
+
+type LanguageRuntime = {
+  parser: TreeSitterParser;
+  captures: RuntimeCapture[];
+};
+
+let ParserCtor: { new (): TreeSitterParser } | null = null;
+
+async function getParserCtor(): Promise<{ new (): TreeSitterParser }> {
+  if (!ParserCtor) {
+    const mod = await import('tree-sitter');
+    ParserCtor = (mod.default ?? mod) as { new (): TreeSitterParser };
+  }
+  return ParserCtor!;
+}
+
+const runtimeCache = new Map<LanguageConfig, Promise<LanguageRuntime>>();
+
+async function getRuntime(config: LanguageConfig): Promise<LanguageRuntime> {
+  if (!runtimeCache.has(config)) {
+    runtimeCache.set(
+      config,
+      (async () => {
+        const ParserClass = await getParserCtor();
+        const languageModule = await config.loader();
+        const language = (languageModule.default ?? languageModule) as TreeSitterLanguage;
+        const parser = new ParserClass();
+        parser.setLanguage(language);
+        const captures = config.captures.map(spec => ({
+          ...spec,
+          capture: spec.capture ?? 'name',
+          compiled: language.query(spec.query),
+        }));
+        return { parser, captures };
+      })()
+    );
+  }
+  return runtimeCache.get(config)!;
+}
+
+const configs: LanguageConfig[] = [
+  {
+    extensions: ['.py'],
+    loader: () => import('tree-sitter-python'),
+    captures: [
+      { type: 'function', query: '(function_definition name: (identifier) @name)', exported: (name) => !name.startsWith('_'), public: (name) => !name.startsWith('_') },
+      { type: 'class', query: '(class_definition name: (identifier) @name)', exported: (name) => !name.startsWith('_'), public: (name) => !name.startsWith('_') },
+    ],
+  },
+  {
+    extensions: ['.go'],
+    loader: () => import('tree-sitter-go'),
+    captures: [
+      { type: 'function', query: '(function_declaration name: (identifier) @name)', exported: (name) => /^[A-Z]/.test(name), public: (name) => /^[A-Z]/.test(name) },
+      { type: 'function', query: '(method_declaration name: (field_identifier) @name)', exported: (name) => /^[A-Z]/.test(name), public: (name) => /^[A-Z]/.test(name) },
+      { type: 'type', query: '(type_spec name: (type_identifier) @name)', exported: (name) => /^[A-Z]/.test(name), public: (name) => /^[A-Z]/.test(name) },
+    ],
+  },
+  {
+    extensions: ['.java'],
+    loader: () => import('tree-sitter-java'),
+    captures: [
+      { type: 'class', query: '(class_declaration name: (identifier) @name)', exported: (_name, node, source) => isPublic(node, source), public: (_name, node, source) => isPublic(node, source) },
+      { type: 'interface', query: '(interface_declaration name: (identifier) @name)', exported: (_name, node, source) => isPublic(node, source), public: (_name, node, source) => isPublic(node, source) },
+      { type: 'enum', query: '(enum_declaration name: (identifier) @name)', exported: (_name, node, source) => isPublic(node, source), public: (_name, node, source) => isPublic(node, source) },
+      { type: 'function', query: '(method_declaration name: (identifier) @name)', exported: (_name, node, source) => isPublic(node, source), public: (_name, node, source) => isPublic(node, source) },
+    ],
+  },
+  {
+    extensions: ['.rs'],
+    loader: () => import('tree-sitter-rust'),
+    captures: [
+      { type: 'function', query: '(function_item name: (identifier) @name)', exported: (name, node, source) => hasPubKeyword(node, source), public: (name, node, source) => hasPubKeyword(node, source) },
+      { type: 'type', query: '(struct_item name: (type_identifier) @name)', exported: (name, node, source) => hasPubKeyword(node, source), public: (name, node, source) => hasPubKeyword(node, source) },
+      { type: 'enum', query: '(enum_item name: (identifier) @name)', exported: (name, node, source) => hasPubKeyword(node, source), public: (name, node, source) => hasPubKeyword(node, source) },
+      { type: 'type', query: '(trait_item name: (identifier) @name)', exported: (name, node, source) => hasPubKeyword(node, source), public: (name, node, source) => hasPubKeyword(node, source) },
+    ],
+  },
+  {
+    extensions: ['.cpp', '.cc', '.cxx', '.hpp', '.h', '.hh'],
+    loader: () => import('tree-sitter-cpp'),
+    captures: [
+      { type: 'class', query: '(class_specifier name: (type_identifier) @name)', public: () => true, exported: () => true },
+      { type: 'function', query: '(function_definition declarator: (function_declarator declarator: (identifier) @name))', public: () => true, exported: () => true },
+      { type: 'function', query: '(function_declaration declarator: (function_declarator declarator: (identifier) @name))', public: () => true, exported: () => true },
+    ],
+  },
+];
+
+function isPublic(node: SyntaxNode, source: string): boolean {
+  const start = Math.max(0, node.startIndex - 32);
+  const prefix = source.slice(start, node.startIndex);
+  return /public\s+$/.test(prefix) || /protected\s+$/.test(prefix);
+}
+
+function hasPubKeyword(node: SyntaxNode, source: string): boolean {
+  const start = Math.max(0, node.startIndex - 12);
+  const prefix = source.slice(start, node.startIndex);
+  return /pub\s*$/.test(prefix);
+}
+
+const FALLBACK_REGEX: Record<string, Array<{ regex: RegExp; type: SymbolRecordType }>> = {
+  '.py': [
+    { regex: /def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g, type: 'function' },
+    { regex: /class\s+([A-Za-z_][A-Za-z0-9_]*)\s*:/g, type: 'class' },
+  ],
+  '.go': [
+    { regex: /func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g, type: 'function' },
+    { regex: /type\s+([A-Za-z_][A-Za-z0-9_]*)\s+struct/g, type: 'type' },
+  ],
+  '.java': [
+    { regex: /class\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'class' },
+    { regex: /interface\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'interface' },
+    { regex: /enum\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'enum' },
+  ],
+  '.rs': [
+    { regex: /fn\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'function' },
+    { regex: /struct\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'type' },
+    { regex: /enum\s+([A-Za-z_][A-Za-z0-9_]*)/g, type: 'enum' },
+  ],
+  '.cpp': [
+    { regex: /([A-Za-z_][A-Za-z0-9_:<>]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g, type: 'function' },
+  ],
+};
+
+function fallbackSymbols(filePath: string, repoRoot: string, source: string): SymbolRecord[] {
+  const ext = path.extname(filePath).toLowerCase();
+  const patterns = FALLBACK_REGEX[ext];
+  if (!patterns) return [];
+  const relative = path.relative(repoRoot, filePath).split(path.sep).join('/');
+  const symbols: SymbolRecord[] = [];
+
+  for (const { regex, type } of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(source)) !== null) {
+      const name = match[1] ?? match[2];
+      if (!name) continue;
+      const before = source.slice(0, match.index);
+      const line = before.split(/\r?\n/).length;
+      symbols.push({
+        name,
+        type,
+        file: relative,
+        line,
+        isPublic: true,
+        isExported: true,
+      });
+    }
+  }
+
+  return symbols;
+}
+
+function uniqueByName(symbols: SymbolRecord[]): SymbolRecord[] {
+  const seen = new Map<string, SymbolRecord>();
+  for (const symbol of symbols) {
+    const key = `${symbol.file}:${symbol.name}:${symbol.line}`;
+    if (!seen.has(key)) {
+      seen.set(key, symbol);
+    }
+  }
+  return Array.from(seen.values());
+}
+
+export async function extractSymbolsForFile(filePath: string, repoRoot: string): Promise<SymbolRecord[]> {
+  const ext = path.extname(filePath).toLowerCase();
+  const config = configs.find(c => c.extensions.includes(ext));
+  const source = await fs.readFile(filePath, 'utf8');
+
+  if (!config) {
+    return [];
+  }
+
+  try {
+    const runtime = await getRuntime(config);
+    const tree = runtime.parser.parse(source);
+    const relative = path.relative(repoRoot, filePath).split(path.sep).join('/');
+    const out: SymbolRecord[] = [];
+
+    for (const capture of runtime.captures) {
+      const results = capture.compiled.captures(tree.rootNode);
+      for (const res of results) {
+        if (res.name !== capture.capture) continue;
+        const node = res.node;
+        const name = source.slice(node.startIndex, node.endIndex);
+        if (!name) continue;
+        const line = node.startPosition.row + 1;
+        const isExported = capture.exported ? capture.exported(name, node, source) : true;
+        const isPublic = capture.public ? capture.public(name, node, source) : isExported;
+
+        out.push({
+          name,
+          type: capture.type,
+          file: relative,
+          line,
+          isPublic,
+          isExported,
+        });
+      }
+    }
+
+    if (!out.length && config.fallback) {
+      return config.fallback(filePath, repoRoot, source);
+    }
+
+    return uniqueByName(out.length ? out : fallbackSymbols(filePath, repoRoot, source));
+  } catch (error) {
+    console.warn(`[extractSymbolsForFile] Tree-sitter failed for ${filePath}:`, (error as Error).message);
+    return fallbackSymbols(filePath, repoRoot, source);
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/memory/architecture.ts
+++ b/packages/thinking-tools-mcp/src/context/memory/architecture.ts
@@ -1,0 +1,108 @@
+import path from 'path';
+import type { SymbolIndex } from '../symbol-index.js';
+import type { ArchitecturalPattern } from './types.js';
+import { BehaviorMemory } from './behavior.js';
+
+type ImportEdge = { from: string; to: string };
+
+function rel(root: string, file: string): string {
+  const abs = path.isAbsolute(file) ? file : path.join(root, file);
+  return path.relative(root, abs).split(path.sep).join('/').toLowerCase();
+}
+
+export class ArchitectureMemory {
+  constructor(private readonly root: string, private readonly behavior: BehaviorMemory) {}
+
+  analyze(symbolIndex: SymbolIndex | null, importGraph: ImportEdge[] | null): ArchitecturalPattern[] {
+    const files = symbolIndex?.files ?? [];
+    const relFiles = files.map(f => rel(this.root, f));
+    const edges = (importGraph ?? []).map(edge => ({ from: rel(this.root, edge.from), to: rel(this.root, edge.to) }));
+
+    const patterns: ArchitecturalPattern[] = [];
+    const now = new Date().toISOString();
+
+    const controllers = relFiles.filter(f => f.includes('controller'));
+    const models = relFiles.filter(f => f.includes('model'));
+    const views = relFiles.filter(f => f.includes('view'));
+    if (controllers.length && models.length) {
+      const mvcConfidence = Math.min(1, (controllers.length + models.length + views.length) / 18);
+      const hasViewEdges = edges.some(e => e.from.includes('controller') && e.to.includes('view'));
+      const confidence = hasViewEdges ? Math.min(1, mvcConfidence + 0.2) : mvcConfidence;
+      patterns.push({
+        name: 'MVC',
+        description: 'Controllers coordinate models' + (views.length ? ' and views' : ''),
+        files: [...controllers, ...models, ...views],
+        confidence,
+        tags: ['controllers', 'models', ...(views.length ? ['views'] : [])],
+        detectedAt: now,
+      });
+    }
+
+    const services = relFiles.filter(f => f.includes('service'));
+    const repositories = relFiles.filter(f => f.includes('repository') || f.includes('repo/'));
+    if (services.length) {
+      const serviceConfidence = Math.min(1, services.length / 12 + (repositories.length ? 0.2 : 0));
+      const svcEdges = edges.filter(e => e.from.includes('controller') && e.to.includes('service'));
+      patterns.push({
+        name: 'Service Layer',
+        description: 'Service layer detected via dedicated service files' + (repositories.length ? ' with repositories' : ''),
+        files: [...services, ...repositories],
+        confidence: Math.min(1, serviceConfidence + (svcEdges.length ? 0.2 : 0)),
+        tags: ['services', ...(repositories.length ? ['repositories'] : [])],
+        detectedAt: now,
+      });
+    }
+
+    const apiHandlers = relFiles.filter(f => f.includes('/api/') || f.includes('handler')); // Next.js / serverless
+    if (apiHandlers.length) {
+      patterns.push({
+        name: 'API Handlers',
+        description: 'HTTP/API handler files detected',
+        files: apiHandlers,
+        confidence: Math.min(1, apiHandlers.length / 16 + 0.2),
+        tags: ['api', 'handlers'],
+        detectedAt: now,
+      });
+    }
+
+    const hasPackagesDir = relFiles.some(f => f.startsWith('packages/'));
+    if (hasPackagesDir) {
+      const packageFiles = relFiles.filter(f => f.startsWith('packages/'));
+      patterns.push({
+        name: 'Monorepo Packages',
+        description: 'Multiple package modules detected (monorepo layout)',
+        files: packageFiles,
+        confidence: Math.min(1, packageFiles.length / 40 + 0.3),
+        tags: ['monorepo', 'packages'],
+        detectedAt: now,
+      });
+    }
+
+    const domains = relFiles.filter(f => f.includes('use-case') || f.includes('domain'));
+    if (domains.length) {
+      patterns.push({
+        name: 'Domain Modules',
+        description: 'Domain-driven structure with use cases/domains',
+        files: domains,
+        confidence: Math.min(1, domains.length / 20 + 0.2),
+        tags: ['domain', 'use-case'],
+        detectedAt: now,
+      });
+    }
+
+    const uiComponents = relFiles.filter(f => f.includes('component') || f.includes('hooks/'));
+    if (uiComponents.length) {
+      patterns.push({
+        name: 'Component Library',
+        description: 'UI components/hooks detected',
+        files: uiComponents,
+        confidence: Math.min(1, uiComponents.length / 25 + 0.2),
+        tags: ['components', 'ui'],
+        detectedAt: now,
+      });
+    }
+
+    this.behavior.updateArchitecture(patterns);
+    return patterns;
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/memory/behavior.ts
+++ b/packages/thinking-tools-mcp/src/context/memory/behavior.ts
@@ -1,0 +1,129 @@
+import path from 'path';
+import { ArchitecturalPattern, StyleMemory } from './types.js';
+import { MemoryStore } from './store.js';
+
+const CAMEL_CASE = /[a-z][a-z0-9]*[A-Z][A-Za-z0-9]*/;
+const SNAKE_CASE = /[a-z0-9]+_[a-z0-9]+/;
+const PASCAL_CASE = /[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*/;
+
+function normalizeFile(root: string, file: string): string {
+  const abs = path.isAbsolute(file) ? file : path.join(root, file);
+  const rel = path.relative(root, abs);
+  return rel.split(path.sep).join('/').toLowerCase();
+}
+
+export class BehaviorMemory {
+  private static cache = new Map<string, BehaviorMemory>();
+
+  static forRoot(root: string): BehaviorMemory {
+    const key = path.resolve(root);
+    if (!this.cache.has(key)) {
+      this.cache.set(key, new BehaviorMemory(root));
+    }
+    return this.cache.get(key)!;
+  }
+
+  private readonly store: MemoryStore;
+
+  private constructor(private readonly workspaceRoot: string) {
+    this.store = MemoryStore.forRoot(workspaceRoot);
+  }
+
+  getStyle(): StyleMemory | null {
+    return this.store.getStyle();
+  }
+
+  updateStyle(style: StyleMemory | null): void {
+    this.store.setStyle(style);
+  }
+
+  getArchitecture(): ArchitecturalPattern[] {
+    return this.store.getArchitecture();
+  }
+
+  updateArchitecture(patterns: ArchitecturalPattern[]): void {
+    this.store.setArchitecture(patterns);
+  }
+
+  recordUsage(file: string): void {
+    this.store.incrementUsage(normalizeFile(this.workspaceRoot, file));
+  }
+
+  usageBoost(file: string): number {
+    const record = this.store.getUsage(normalizeFile(this.workspaceRoot, file));
+    if (!record) return 0;
+    return Math.min(0.5, Math.log1p(record.count) / 4);
+  }
+
+  architectureBoost(file: string): { score: number; tags: string[] } {
+    const norm = normalizeFile(this.workspaceRoot, file);
+    const patterns = this.store.getArchitecture();
+    if (!patterns.length) {
+      return { score: 0, tags: [] };
+    }
+
+    let score = 0;
+    const tags = new Set<string>();
+
+    for (const pattern of patterns) {
+      const matches = pattern.files.some(f => normalizeFile(this.workspaceRoot, f) === norm);
+      const partial = pattern.files.some(f => norm.startsWith(normalizeFile(this.workspaceRoot, f)));
+      if (matches || partial) {
+        score += pattern.confidence * (matches ? 0.9 : 0.6);
+        tags.add(pattern.name);
+      }
+    }
+
+    return { score: Math.min(1, score), tags: Array.from(tags) };
+  }
+
+  styleBoost(snippet: string): number {
+    const style = this.store.getStyle();
+    if (!style) return 0;
+
+    const text = snippet ?? '';
+    let score = 0;
+
+    if (style.namingPreference === 'camelCase' && CAMEL_CASE.test(text)) {
+      score += 0.6 * style.namingConfidence;
+    } else if (style.namingPreference === 'snake_case' && SNAKE_CASE.test(text)) {
+      score += 0.6 * style.namingConfidence;
+    } else if (style.namingPreference === 'pascalCase' && PASCAL_CASE.test(text)) {
+      score += 0.6 * style.namingConfidence;
+    } else if (style.namingPreference === 'kebab-case' && text.includes('-')) {
+      score += 0.4 * style.namingConfidence;
+    }
+
+    const lines = text.split(/\r?\n/).filter(l => l.trim().length > 0);
+    if (style.indentStyle === 'spaces') {
+      const spaces = lines.filter(l => /^ +\S/.test(l)).length;
+      if (spaces > 0) {
+        const ratio = spaces / lines.length;
+        score += 0.2 * Math.min(1, ratio);
+      }
+      if (style.indentSize) {
+        const exact = lines.filter(l => new RegExp(`^ {${style.indentSize}}`).test(l)).length;
+        if (exact > 0) {
+          score += 0.1 * Math.min(1, exact / lines.length);
+        }
+      }
+    } else if (style.indentStyle === 'tabs') {
+      const tabs = lines.filter(l => /^\t+\S/.test(l)).length;
+      if (tabs > 0) {
+        score += 0.25 * Math.min(1, tabs / lines.length);
+      }
+    }
+
+    if (style.quoteStyle === 'single') {
+      const singles = (text.match(/'/g) || []).length;
+      const doubles = (text.match(/"/g) || []).length;
+      if (singles > doubles) score += 0.1;
+    } else if (style.quoteStyle === 'double') {
+      const singles = (text.match(/'/g) || []).length;
+      const doubles = (text.match(/"/g) || []).length;
+      if (doubles >= singles) score += 0.1;
+    }
+
+    return Math.min(1, score);
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/memory/store.ts
+++ b/packages/thinking-tools-mcp/src/context/memory/store.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import { ArchitecturalPattern, MemoryData, StyleMemory, UsageRecord } from './types.js';
+
+const MEMORY_VERSION = 1;
+const instances = new Map<string, MemoryStore>();
+
+function normalizeRoot(root: string): string {
+  return path.resolve(root);
+}
+
+function defaultData(): MemoryData {
+  return {
+    version: MEMORY_VERSION,
+    updatedAt: new Date().toISOString(),
+    style: null,
+    architecture: [],
+    usage: {},
+  };
+}
+
+export class MemoryStore {
+  static forRoot(root: string): MemoryStore {
+    const key = normalizeRoot(root);
+    if (!instances.has(key)) {
+      instances.set(key, new MemoryStore(key));
+    }
+    return instances.get(key)!;
+  }
+
+  private readonly memoryPath: string;
+  private data: MemoryData;
+
+  private constructor(private readonly workspaceRoot: string) {
+    const dir = path.join(this.workspaceRoot, '.robinson', 'context');
+    fs.mkdirSync(dir, { recursive: true });
+    this.memoryPath = path.join(dir, 'memory.json');
+    this.data = this.read();
+  }
+
+  getStyle(): StyleMemory | null {
+    return this.data.style;
+  }
+
+  setStyle(style: StyleMemory | null): void {
+    this.data.style = style;
+    this.touch();
+  }
+
+  getArchitecture(): ArchitecturalPattern[] {
+    return this.data.architecture;
+  }
+
+  setArchitecture(patterns: ArchitecturalPattern[]): void {
+    this.data.architecture = patterns;
+    this.touch();
+  }
+
+  getUsage(file: string): UsageRecord | undefined {
+    return this.data.usage[file];
+  }
+
+  incrementUsage(file: string): UsageRecord {
+    const key = file.toLowerCase();
+    const existing = this.data.usage[key] ?? { count: 0, lastAccessed: new Date(0).toISOString() };
+    const record: UsageRecord = {
+      count: existing.count + 1,
+      lastAccessed: new Date().toISOString(),
+    };
+    this.data.usage[key] = record;
+    this.touch();
+    return record;
+  }
+
+  getUsageMap(): Record<string, UsageRecord> {
+    return this.data.usage;
+  }
+
+  private read(): MemoryData {
+    if (!fs.existsSync(this.memoryPath)) {
+      return defaultData();
+    }
+
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.memoryPath, 'utf8')) as MemoryData;
+      if (!parsed.version || parsed.version < MEMORY_VERSION) {
+        return {
+          ...defaultData(),
+          style: parsed.style ?? null,
+          architecture: parsed.architecture ?? [],
+          usage: parsed.usage ?? {},
+        };
+      }
+      return parsed;
+    } catch (error) {
+      console.warn('[MemoryStore] Failed to parse memory file, resetting:', (error as Error).message);
+      return defaultData();
+    }
+  }
+
+  private touch(): void {
+    this.data.updatedAt = new Date().toISOString();
+    this.flush();
+  }
+
+  private flush(): void {
+    try {
+      fs.writeFileSync(this.memoryPath, JSON.stringify(this.data, null, 2), 'utf8');
+    } catch (error) {
+      console.warn('[MemoryStore] Failed to persist memory file:', (error as Error).message);
+    }
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/memory/style.ts
+++ b/packages/thinking-tools-mcp/src/context/memory/style.ts
@@ -1,0 +1,180 @@
+import fs from 'fs/promises';
+import { BehaviorMemory } from './behavior.js';
+import type { StyleMemory } from './types.js';
+
+const IDENTIFIER_REGEX = /[A-Za-z_][A-Za-z0-9_-]{3,}/g;
+
+function isCamelCase(id: string): boolean {
+  return /^[a-z]+[A-Za-z0-9]*$/.test(id) && /[A-Z]/.test(id);
+}
+
+function isSnakeCase(id: string): boolean {
+  return /^[a-z0-9]+(_[a-z0-9]+)+$/.test(id);
+}
+
+function isPascalCase(id: string): boolean {
+  return /^[A-Z][A-Za-z0-9]+$/.test(id) && /[a-z]/.test(id);
+}
+
+function isKebabCase(id: string): boolean {
+  return /^[a-z0-9]+(-[a-z0-9]+)+$/.test(id);
+}
+
+export class StyleLearner {
+  constructor(private readonly behavior: BehaviorMemory) {}
+
+  async analyze(files: string[]): Promise<StyleMemory | null> {
+    if (!files.length) return null;
+
+    const sampleSize = Math.min(files.length, parseInt(process.env.RCE_STYLE_SAMPLE ?? '180', 10));
+    const sample = files.slice(0, sampleSize);
+
+    const counts = { camel: 0, snake: 0, pascal: 0, kebab: 0 };
+    const examples = {
+      camel: new Set<string>(),
+      snake: new Set<string>(),
+      pascal: new Set<string>(),
+      kebab: new Set<string>(),
+    } as Record<'camel' | 'snake' | 'pascal' | 'kebab', Set<string>>;
+
+    let singleQuotes = 0;
+    let doubleQuotes = 0;
+    let tabIndents = 0;
+    let spaceIndents = 0;
+    const indentSizes = new Map<number, number>();
+    let relativeImports = 0;
+    let absoluteImports = 0;
+
+    for (const file of sample) {
+      try {
+        const text = await fs.readFile(file, 'utf8');
+        const trimmed = text.slice(0, 8000);
+
+        const identifiers = trimmed.match(IDENTIFIER_REGEX) ?? [];
+        for (const id of identifiers.slice(0, 60)) {
+          if (isCamelCase(id)) {
+            counts.camel++;
+            if (examples.camel.size < 12) examples.camel.add(id);
+          } else if (isSnakeCase(id)) {
+            counts.snake++;
+            if (examples.snake.size < 12) examples.snake.add(id);
+          } else if (isPascalCase(id)) {
+            counts.pascal++;
+            if (examples.pascal.size < 12) examples.pascal.add(id);
+          } else if (isKebabCase(id)) {
+            counts.kebab++;
+            if (examples.kebab.size < 12) examples.kebab.add(id);
+          }
+        }
+
+        singleQuotes += (trimmed.match(/'/g) || []).length;
+        doubleQuotes += (trimmed.match(/"/g) || []).length;
+
+        const lines = trimmed.split(/\r?\n/).slice(0, 220);
+        for (const line of lines) {
+          const leading = line.match(/^[\t ]+/);
+          if (!leading) continue;
+          if (leading[0].includes('\t')) {
+            tabIndents++;
+          } else {
+            spaceIndents++;
+            const size = leading[0].length;
+            if (size > 0 && size <= 8) {
+              indentSizes.set(size, (indentSizes.get(size) ?? 0) + 1);
+            }
+          }
+
+          if (/\bimport\b/.test(line) || /require\(/.test(line) || /from\s+['".]/.test(line)) {
+            if (line.includes('../') || line.includes('./')) {
+              relativeImports++;
+            } else if (line.includes("'@") || line.includes('"@') || line.includes(' from ')) {
+              absoluteImports++;
+            }
+          }
+        }
+      } catch {
+        // Ignore unreadable files
+      }
+    }
+
+    const totalIdentifiers = counts.camel + counts.snake + counts.pascal + counts.kebab;
+    let namingPreference: StyleMemory['namingPreference'] = 'unknown';
+    let namingConfidence = 0;
+    let identifierExamples: string[] = [];
+
+    const ranking: Array<{ key: 'camel' | 'snake' | 'pascal' | 'kebab'; count: number }> = [
+      { key: 'camel' as const, count: counts.camel },
+      { key: 'snake' as const, count: counts.snake },
+      { key: 'pascal' as const, count: counts.pascal },
+      { key: 'kebab' as const, count: counts.kebab },
+    ].sort((a, b) => b.count - a.count);
+
+    if (totalIdentifiers > 0 && ranking[0].count > 0) {
+      namingPreference =
+        ranking[0].key === 'camel'
+          ? 'camelCase'
+          : ranking[0].key === 'snake'
+            ? 'snake_case'
+            : ranking[0].key === 'pascal'
+              ? 'pascalCase'
+              : 'kebab-case';
+      namingConfidence = ranking[0].count / totalIdentifiers;
+      if (namingConfidence < 0.35) {
+        namingPreference = 'mixed';
+      }
+      identifierExamples = Array.from(examples[ranking[0].key]).slice(0, 8);
+    }
+
+    let indentStyle: StyleMemory['indentStyle'] = 'mixed';
+    if (tabIndents > spaceIndents * 1.2) {
+      indentStyle = 'tabs';
+    } else if (spaceIndents >= tabIndents) {
+      indentStyle = spaceIndents === 0 ? 'mixed' : 'spaces';
+    }
+
+    let indentSize: number | undefined;
+    if (indentStyle === 'spaces' && indentSizes.size) {
+      const [size] = Array.from(indentSizes.entries()).sort((a, b) => b[1] - a[1])[0];
+      indentSize = size;
+    }
+
+    let quoteStyle: StyleMemory['quoteStyle'] = 'unknown';
+    if (singleQuotes === 0 && doubleQuotes === 0) {
+      quoteStyle = 'unknown';
+    } else if (singleQuotes > doubleQuotes * 1.1) {
+      quoteStyle = 'single';
+    } else if (doubleQuotes > singleQuotes * 1.1) {
+      quoteStyle = 'double';
+    } else {
+      quoteStyle = 'mixed';
+    }
+
+    let importStyle: StyleMemory['importStyle'];
+    if (relativeImports === 0 && absoluteImports === 0) {
+      importStyle = undefined;
+    } else if (relativeImports > absoluteImports * 1.2) {
+      importStyle = 'relative';
+    } else if (absoluteImports > relativeImports * 1.2) {
+      importStyle = 'absolute';
+    } else {
+      importStyle = 'mixed';
+    }
+
+    const keywords = identifierExamples.slice(0, 6);
+
+    const style: StyleMemory = {
+      namingPreference,
+      namingConfidence,
+      identifierExamples,
+      indentStyle,
+      indentSize,
+      quoteStyle,
+      importStyle,
+      keywords,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.behavior.updateStyle(style);
+    return style;
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/memory/types.ts
+++ b/packages/thinking-tools-mcp/src/context/memory/types.ts
@@ -1,0 +1,33 @@
+export interface StyleMemory {
+  namingPreference: 'camelCase' | 'snake_case' | 'pascalCase' | 'kebab-case' | 'mixed' | 'unknown';
+  namingConfidence: number;
+  identifierExamples: string[];
+  indentStyle: 'spaces' | 'tabs' | 'mixed';
+  indentSize?: number;
+  quoteStyle: 'single' | 'double' | 'mixed' | 'unknown';
+  importStyle?: 'relative' | 'absolute' | 'mixed';
+  keywords?: string[];
+  updatedAt: string;
+}
+
+export interface ArchitecturalPattern {
+  name: string;
+  description: string;
+  files: string[];
+  confidence: number; // 0-1
+  tags: string[];
+  detectedAt: string;
+}
+
+export interface UsageRecord {
+  count: number;
+  lastAccessed: string;
+}
+
+export interface MemoryData {
+  version: number;
+  updatedAt: string;
+  style: StyleMemory | null;
+  architecture: ArchitecturalPattern[];
+  usage: Record<string, UsageRecord>;
+}

--- a/packages/thinking-tools-mcp/src/context/quick-search.ts
+++ b/packages/thinking-tools-mcp/src/context/quick-search.ts
@@ -1,0 +1,111 @@
+import fs from 'fs/promises';
+import path from 'path';
+import fg from 'fast-glob';
+import { lexicalRank } from './search.js';
+
+export interface QuickHit {
+  uri: string;
+  title: string;
+  snippet: string;
+  score: number;
+  source: 'quick';
+}
+
+const FILE_GLOB = ['**/*.{ts,tsx,js,jsx,py,go,java,rs,cpp,c,h,cs,rb,php}'];
+const FILE_IGNORE = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/vendor/**',
+  '**/.venv*/**',
+  '**/venv/**',
+  '**/__pycache__/**',
+  '**/.idea/**',
+];
+
+function highlight(text: string, term: string): string {
+  const idx = text.toLowerCase().indexOf(term.toLowerCase());
+  if (idx === -1) {
+    return text.slice(0, 320);
+  }
+  const start = Math.max(0, idx - 120);
+  const end = Math.min(text.length, idx + term.length + 180);
+  return text.slice(start, end);
+}
+
+export class QuickSearch {
+  private files: string[] = [];
+  private lastIndexed = 0;
+  private readonly ttlMs = 5 * 60 * 1000;
+  private readonly maxFiles = parseInt(process.env.RCE_QUICK_MAX_FILES ?? '400', 10);
+
+  constructor(private readonly root: string) {}
+
+  private async refreshIfNeeded(): Promise<void> {
+    const now = Date.now();
+    if (this.files.length && now - this.lastIndexed < this.ttlMs) {
+      return;
+    }
+
+    try {
+      const matches = await fg(FILE_GLOB, {
+        cwd: this.root,
+        ignore: FILE_IGNORE,
+        absolute: true,
+        dot: false,
+      });
+      this.files = matches.slice(0, this.maxFiles);
+      this.lastIndexed = now;
+    } catch (error) {
+      console.warn('[QuickSearch] Failed to refresh file list:', (error as Error).message);
+    }
+  }
+
+  async search(query: string, limit: number): Promise<QuickHit[]> {
+    const terms = query.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    if (!terms.length) return [];
+
+    await this.refreshIfNeeded();
+    if (!this.files.length) return [];
+
+    const prioritized = this.files
+      .filter(f => terms.some(term => f.toLowerCase().includes(term)))
+      .concat(this.files)
+      .slice(0, Math.min(this.maxFiles, 200));
+
+    const seen = new Set<string>();
+    const hits: QuickHit[] = [];
+
+    for (const file of prioritized) {
+      const rel = path.relative(this.root, file).split(path.sep).join('/');
+      if (seen.has(rel)) continue;
+      seen.add(rel);
+
+      try {
+        const text = await fs.readFile(file, 'utf8');
+        const snippet = highlight(text, terms[0]);
+        const score = lexicalRank(query, text.slice(0, 16000));
+        if (score <= 0) continue;
+        hits.push({
+          uri: rel,
+          title: path.basename(rel),
+          snippet,
+          score,
+          source: 'quick',
+        });
+      } catch {
+        // ignore unreadable files
+      }
+
+      if (hits.length >= limit * 2) break;
+    }
+
+    return hits
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map(hit => ({ ...hit, score: Math.max(0.05, hit.score) }));
+  }
+}

--- a/packages/thinking-tools-mcp/src/context/search.ts
+++ b/packages/thinking-tools-mcp/src/context/search.ts
@@ -1,4 +1,4 @@
-import { readJSONL, getPaths } from './store.js';
+import { readJSONL, getPaths, iterateChunks } from './store.js';
 import { cosine } from './embedding.js';
 import { Hit, Chunk, Embedding } from './types.js';
 import { getQueryCache } from './cache.js';
@@ -45,7 +45,7 @@ export async function hybridQuery(query: string, topK = 8): Promise<Hit[]> {
   // Stream chunks and score incrementally
   const scored: Hit[] = [];
   try {
-    for (const chunk of readJSONL<Chunk>(paths.chunks)) {
+    for (const chunk of iterateChunks()) {
       const v = embMap.get(chunk.id);
       let s = v ? cosine(qvec, v) : 0;
       s = 0.80 * s + 0.20 * lexicalRank(query, chunk.text);

--- a/packages/thinking-tools-mcp/src/context/store.ts
+++ b/packages/thinking-tools-mcp/src/context/store.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import { gzipSync, gunzipSync } from 'zlib';
 import { Chunk, Embedding, IndexStats } from './types.js';
 import { resolveWorkspaceRoot } from '../lib/workspace.js';
 
@@ -8,7 +9,7 @@ import { resolveWorkspaceRoot } from '../lib/workspace.js';
 export type StoredDoc = import('./docs/types.js').DocRecord;
 
 // Resolve paths relative to workspace root, not process.cwd()
-function getContextRoot(): string {
+function resolveContextRootPath(): string {
   if (process.env.CTX_ROOT) {
     return path.isAbsolute(process.env.CTX_ROOT)
       ? process.env.CTX_ROOT
@@ -17,7 +18,11 @@ function getContextRoot(): string {
   return path.join(resolveWorkspaceRoot(), '.robinson/context');
 }
 
-const root = getContextRoot();
+const root = resolveContextRootPath();
+
+export function getContextRoot(): string {
+  return root;
+}
 
 const P = {
   chunks: path.join(root, 'chunks.jsonl'),
@@ -27,6 +32,14 @@ const P = {
   files: path.join(root, 'files.json'),
   embedCache: path.join(root, 'embed-cache')
 };
+
+const compressionMode = (process.env.RCE_COMPRESSION ?? 'auto').toLowerCase();
+const compressionThreshold = parseInt(process.env.RCE_COMPRESSION_THRESHOLD ?? '4096', 10);
+
+function shouldCompressChunks(): boolean {
+  if (compressionMode === 'auto') return true;
+  return compressionMode === 'on' || compressionMode === 'true' || compressionMode === '1';
+}
 
 export function ensureDirs() {
   fs.mkdirSync(path.dirname(P.chunks), { recursive: true });
@@ -56,7 +69,7 @@ export function writeJSON(p: string, obj: any) {
 }
 
 export function loadChunks(): Chunk[] {
-  return Array.from(readJSONL<Chunk>(P.chunks));
+  return Array.from(iterateChunks());
 }
 
 export function loadEmbeddings(): Embedding[] {
@@ -64,11 +77,26 @@ export function loadEmbeddings(): Embedding[] {
 }
 
 export function saveChunk(c: Chunk) {
-  appendJSONL(P.chunks, c);
+  appendJSONL(P.chunks, serializeChunk(c));
 }
 
 export function saveEmbedding(e: Embedding) {
   appendJSONL(P.embeds, e);
+}
+
+export function deleteEmbeddingsById(ids: Set<string>) {
+  if (ids.size === 0) return;
+  if (!fs.existsSync(P.embeds)) return;
+
+  const remaining: Embedding[] = [];
+  for (const embedding of readJSONL<Embedding>(P.embeds)) {
+    if (!ids.has(embedding.id)) {
+      remaining.push(embedding);
+    }
+  }
+
+  const payload = remaining.map(e => JSON.stringify(e)).join('\n');
+  fs.writeFileSync(P.embeds, payload ? payload + '\n' : '', 'utf8');
 }
 
 export function saveStats(s: IndexStats) {
@@ -88,6 +116,109 @@ export function getStats(): IndexStats | null {
 
 export function getPaths() {
   return P;
+}
+
+function countJsonlLines(filePath: string): number {
+  if (!fs.existsSync(filePath)) return 0;
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (!content) return 0;
+  return content.split(/\r?\n/).filter(Boolean).length;
+}
+
+export function recomputeStats(partial: Partial<IndexStats> = {}): IndexStats {
+  const prev = getStats();
+  const now = new Date().toISOString();
+
+  const chunkCount = countJsonlLines(P.chunks);
+  const embedCount = countJsonlLines(P.embeds);
+
+  const base: IndexStats = {
+    chunks: chunkCount,
+    embeddings: embedCount,
+    vectors: embedCount,
+    sources: prev?.sources ?? {},
+    mode: prev?.mode ?? 'unknown',
+    model: prev?.model ?? 'unknown',
+    dimensions: prev?.dimensions ?? 0,
+    totalCost: prev?.totalCost ?? 0,
+    indexedAt: prev?.indexedAt ?? prev?.updatedAt ?? now,
+    updatedAt: now,
+  };
+
+  const next: IndexStats = { ...base, ...partial };
+  next.vectors = typeof next.embeddings === 'number' ? next.embeddings : Number(next.embeddings || 0);
+  saveStats(next);
+  return next;
+}
+
+type SerializedChunk = Omit<Chunk, 'text'> & {
+  text: string;
+};
+
+function serializeChunk(chunk: Chunk): SerializedChunk {
+  if (!shouldCompressChunks()) {
+    return { ...chunk };
+  }
+
+  const text = chunk.text ?? '';
+  const bytes = Buffer.byteLength(text, 'utf8');
+  if (bytes < compressionThreshold) {
+    return { ...chunk };
+  }
+
+  try {
+    const compressed = gzipSync(text);
+    return {
+      ...chunk,
+      text: compressed.toString('base64'),
+      compressed: true,
+      compressedSize: compressed.length,
+      originalSize: bytes,
+    };
+  } catch (error) {
+    console.warn('[serializeChunk] Compression failed, writing plain text:', (error as Error).message);
+    return { ...chunk };
+  }
+}
+
+function hydrateChunk(raw: any): Chunk {
+  if (!raw) return raw;
+
+  if (raw.compressed && typeof raw.text === 'string') {
+    try {
+      const buffer = Buffer.from(raw.text, 'base64');
+      const text = gunzipSync(buffer).toString('utf8');
+      return {
+        ...raw,
+        text,
+        compressed: true,
+        compressedSize: raw.compressedSize ?? buffer.length,
+        originalSize: raw.originalSize ?? Buffer.byteLength(text, 'utf8'),
+      };
+    } catch (error) {
+      console.warn('[hydrateChunk] Failed to decompress chunk, returning raw text:', (error as Error).message);
+      return {
+        ...raw,
+        text: raw.text,
+        compressed: false,
+        compressedSize: undefined,
+        originalSize: Buffer.byteLength(String(raw.text ?? ''), 'utf8'),
+      };
+    }
+  }
+
+  return {
+    ...raw,
+    compressed: !!raw.compressed,
+    compressedSize: raw.compressedSize,
+    originalSize: raw.originalSize ?? Buffer.byteLength(String(raw.text ?? ''), 'utf8'),
+  };
+}
+
+export function* iterateChunks(): Generator<Chunk> {
+  for (const raw of readJSONL<any>(P.chunks)) {
+    yield hydrateChunk(raw);
+  }
 }
 
 // Document storage functions
@@ -121,7 +252,8 @@ export function deleteChunksForFile(file: string) {
   const all = loadChunks();
   const keep = all.filter(c => c.path !== file && c.uri !== file);
   // Rewrite chunks file
-  fs.writeFileSync(P.chunks, keep.map(c => JSON.stringify(c)).join('\n') + '\n', 'utf8');
+  const serialized = keep.map(c => JSON.stringify(serializeChunk(c))).join('\n');
+  fs.writeFileSync(P.chunks, serialized ? serialized + '\n' : '', 'utf8');
 }
 
 // --- Embeddings cache: model|sha -> vector
@@ -150,5 +282,99 @@ export function putCachedVec(model: string, sha: string, vec: number[]) {
 
 export function sha(text: string): string {
   return crypto.createHash('sha1').update(text).digest('hex');
+}
+
+function safeStat(p: string): fs.Stats | null {
+  try {
+    return fs.statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function dirSize(p: string): number {
+  const stat = safeStat(p);
+  if (!stat) return 0;
+  if (stat.isFile()) return stat.size;
+
+  let total = 0;
+  try {
+    const entries = fs.readdirSync(p, { withFileTypes: true });
+    for (const entry of entries) {
+      const child = path.join(p, entry.name);
+      total += dirSize(child);
+    }
+  } catch {}
+  return total;
+}
+
+export function estimateDiskUsage(): number {
+  return dirSize(root);
+}
+
+function cleanupEmbedCache(budgetBytes: number): number {
+  if (!fs.existsSync(P.embedCache)) return 0;
+  let freed = 0;
+  try {
+    const entries = fs.readdirSync(P.embedCache).map(name => {
+      const full = path.join(P.embedCache, name);
+      const stat = safeStat(full);
+      return stat ? { name, full, mtime: stat.mtimeMs, size: stat.size } : null;
+    }).filter(Boolean) as Array<{ name: string; full: string; mtime: number; size: number }>;
+
+    entries.sort((a, b) => a.mtime - b.mtime);
+
+    for (const entry of entries) {
+      if (estimateDiskUsage() <= budgetBytes) break;
+      try {
+        fs.unlinkSync(entry.full);
+        freed += entry.size;
+      } catch {}
+    }
+  } catch (error) {
+    console.warn('[storage] Failed to clean embed cache:', (error as Error).message);
+  }
+  return freed;
+}
+
+function pruneDocsIfNeeded(budgetBytes: number): number {
+  if (!fs.existsSync(P.docs)) return 0;
+  const usage = estimateDiskUsage();
+  if (usage <= budgetBytes) return 0;
+
+  let freed = 0;
+  try {
+    const docs = Array.from(readJSONL<any>(P.docs));
+    if (docs.length < 50) return 0;
+    const trimmed = docs.slice(Math.floor(docs.length / 2));
+    fs.writeFileSync(P.docs, trimmed.map(d => JSON.stringify(d)).join('\n') + '\n', 'utf8');
+    freed = usage - estimateDiskUsage();
+  } catch (error) {
+    console.warn('[storage] Failed to prune docs cache:', (error as Error).message);
+  }
+  return freed;
+}
+
+export function applyStoragePolicy(): { usage: number; budgetMb: number; reclaimed: number } {
+  const budgetMb = Number(process.env.RCE_MAX_DISK_MB ?? '512');
+  if (budgetMb <= 0) {
+    return { usage: estimateDiskUsage(), budgetMb, reclaimed: 0 };
+  }
+
+  const budgetBytes = budgetMb * 1024 * 1024;
+  let usage = estimateDiskUsage();
+  let reclaimed = 0;
+
+  if (usage > budgetBytes) {
+    reclaimed += cleanupEmbedCache(budgetBytes);
+    usage = estimateDiskUsage();
+  }
+
+  if (usage > budgetBytes) {
+    reclaimed += pruneDocsIfNeeded(budgetBytes);
+    usage = estimateDiskUsage();
+  }
+
+  return { usage, budgetMb, reclaimed };
 }
 

--- a/packages/thinking-tools-mcp/src/context/symbols.ts
+++ b/packages/thinking-tools-mcp/src/context/symbols.ts
@@ -18,7 +18,31 @@ export function extractSymbols(langExt: string, text: string): string[] {
   if (['.go'].includes(langExt)) {
     add((text.match(/func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g) || []).map(s=>s.split(/\s+/)[1].replace('(','').trim()));
   }
-  // Java/Rust are similar – add if needed
+  // Java
+  if (['.java'].includes(langExt)) {
+    add((text.match(/class\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/interface\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/enum\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/(?:public\s+)?(?:static\s+)?[A-Za-z0-9_<>\[\]]+\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g) || [])
+      .map(s => s.replace(/.*\s+/, '').replace('(', '').trim()));
+  }
+  // Rust
+  if (['.rs'].includes(langExt)) {
+    add((text.match(/fn\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/struct\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/enum\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/trait\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+  }
+  // C/C++
+  if (['.cpp','.cc','.cxx','.c','.h','.hpp','.hh'].includes(langExt)) {
+    add((text.match(/([A-Za-z_][A-Za-z0-9_:<>]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g) || [])
+      .map(s=>{
+        const parts = s.replace('(', '').trim().split(/\s+/);
+        return parts[parts.length-1];
+      }));
+    add((text.match(/class\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+    add((text.match(/struct\s+([A-Za-z_][A-Za-z0-9_]*)/g) || []).map(s=>s.split(/\s+/)[1]));
+  }
 
   return Array.from(out).slice(0, 200); // cap
 }

--- a/packages/thinking-tools-mcp/src/context/types.ts
+++ b/packages/thinking-tools-mcp/src/context/types.ts
@@ -13,7 +13,15 @@ export interface Chunk {
   tokens?: number;
   tags?: string[];
   vec?: number[];  // Optional embedding vector (for reranking)
-  meta?: { symbols?: string[]; lang?: string; lines?: number };  // Symbol extraction metadata
+  meta?: {
+    symbols?: string[];
+    lang?: string;
+    lines?: number;
+    architectureTags?: string[];
+  };  // Symbol extraction metadata
+  compressed?: boolean;
+  compressedSize?: number;
+  originalSize?: number;
 }
 
 export interface Embedding {

--- a/packages/thinking-tools-mcp/src/lib/context.ts
+++ b/packages/thinking-tools-mcp/src/lib/context.ts
@@ -7,6 +7,7 @@ import { state, SessionKey } from './state.js';
 import { resolveWorkspaceRoot } from './workspace.js';
 import { ContextEngine } from '../context/engine.js';
 import { EvidenceStore, EvidenceItem } from '../context/evidence.js';
+import { applyContextDefaults } from '../context/config.js';
 
 export type ServerContext = {
   workspaceRoot: string;
@@ -30,6 +31,8 @@ let _ranking: 'local' | 'imported' | 'blend' =
  * Extracts workspace root and conversation ID, provides state accessors
  */
 export function buildServerContext(args: any): ServerContext {
+  applyContextDefaults();
+
   const workspaceRoot = resolveWorkspaceRoot();
   const convoId = String(args?.convoId ?? args?.conversationId ?? 'default');
 

--- a/packages/thinking-tools-mcp/src/tools/context_index_full.ts
+++ b/packages/thinking-tools-mcp/src/tools/context_index_full.ts
@@ -14,7 +14,8 @@ export async function contextIndexFullTool(_: {}, ctx: ServerContext) {
   try {
     // Force full rebuild by passing quick: false
     const res = await indexRepo(ctx.workspaceRoot, { quick: false, force: true });
-    
+    await ctx.ctx.reloadFromDisk();
+
     return {
       content: [{
         type: 'text' as const,

--- a/packages/thinking-tools-mcp/src/tools/context_index_repo.ts
+++ b/packages/thinking-tools-mcp/src/tools/context_index_repo.ts
@@ -23,6 +23,7 @@ export async function contextIndexRepoTool(args: any, ctx: ServerContext) {
     // If force flag is set, call indexRepo directly with force option
     if (args?.force) {
       await indexRepo(ctx.workspaceRoot, { force: true });
+      await ctx.ctx.reloadFromDisk();
     } else {
       await ctx.ctx.ensureIndexed();
     }

--- a/packages/thinking-tools-mcp/src/types/tree-sitter.d.ts
+++ b/packages/thinking-tools-mcp/src/types/tree-sitter.d.ts
@@ -1,0 +1,30 @@
+declare module 'tree-sitter' {
+  const Parser: any;
+  export default Parser;
+}
+
+declare module 'tree-sitter-python' {
+  const language: any;
+  export default language;
+}
+
+declare module 'tree-sitter-go' {
+  const language: any;
+  export default language;
+}
+
+declare module 'tree-sitter-java' {
+  const language: any;
+  export default language;
+}
+
+declare module 'tree-sitter-rust' {
+  const language: any;
+  export default language;
+}
+
+declare module 'tree-sitter-cpp' {
+  const language: any;
+  export default language;
+}
+


### PR DESCRIPTION
## Summary
- add a zero-config bootstrap that selects the best embedding provider automatically and pre-fills safe defaults for context indexing
- refresh the context engine caches whenever the index changes, wiring the file watcher and manual indexing tools to rebuild symbol/architecture memory without reindexing from scratch
- teach the watcher to rewrite chunk/embedding files, recompute stats, and add minimal tree-sitter module declarations so TypeScript builds succeed

## Testing
- pnpm --filter thinking-tools-mcp build

------
https://chatgpt.com/codex/tasks/task_e_690ad0db6ed8832ba8dd19f9726de8ba