### PR TITLE
Add regression checks for context engine heuristics

### DIFF
--- a/packages/thinking-tools-mcp/package.json
+++ b/packages/thinking-tools-mcp/package.json
@@ -21,6 +21,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc -p tsconfig.json",
+    "pretest": "pnpm run build",
+    "test": "node test/run-tests.mjs",
     "prepublishOnly": "node ../../scripts/ensure-no-workspace.mjs",
     "start": "node bin/thinking-tools-mcp.js",
     "smoke": "node scripts/handshake-smoke.mjs"

--- a/packages/thinking-tools-mcp/test/context/architecture.test.mjs
+++ b/packages/thinking-tools-mcp/test/context/architecture.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { ArchitectureMemory } from '../../dist/context/architecture.js';
+
+function createSymbol(name, file) {
+  return {
+    name,
+    type: 'class',
+    file,
+    line: 1,
+    language: 'typescript',
+    isPublic: true,
+    isExported: true,
+  };
+}
+
+export default async function testArchitectureMemory() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'arch-root-'));
+  const symbolIndex = {
+    symbols: [
+      createSymbol('UserController', 'src/controllers/UserController.ts'),
+      createSymbol('AdminController', 'src/controllers/AdminController.ts'),
+      createSymbol('UserService', 'src/services/UserService.ts'),
+      createSymbol('AuditService', 'src/services/AuditService.ts'),
+      createSymbol('UserRepository', 'src/repositories/UserRepository.ts'),
+      createSymbol('AppComponent', 'src/components/AppComponent.tsx'),
+      createSymbol('DashboardComponent', 'src/components/DashboardComponent.tsx'),
+      createSymbol('FooterComponent', 'src/components/FooterComponent.tsx'),
+      createSymbol('useDashboard', 'src/hooks/useDashboard.ts'),
+      createSymbol('AppContext', 'src/context/AppContext.ts'),
+      createSymbol('OrderDomainService', 'src/domain/orders/OrderDomainService.ts'),
+      createSymbol('OrderApplicationService', 'src/application/orders/OrderApplicationService.ts'),
+      createSymbol('OrderInfrastructureService', 'src/infrastructure/orders/OrderInfrastructureService.ts'),
+      createSymbol('McpRegistry', 'packages/mcp/server.ts'),
+      createSymbol('ContextEngine', 'src/engine/ContextEngine.ts'),
+      createSymbol('ContextIndexerEngine', 'src/engine/ContextIndexerEngine.ts'),
+    ],
+    files: [
+      path.join(root, 'src/controllers/UserController.ts'),
+      path.join(root, 'src/controllers/AdminController.ts'),
+      path.join(root, 'src/services/UserService.ts'),
+      path.join(root, 'src/services/AuditService.ts'),
+      path.join(root, 'src/repositories/UserRepository.ts'),
+      path.join(root, 'src/components/AppComponent.tsx'),
+      path.join(root, 'src/components/DashboardComponent.tsx'),
+      path.join(root, 'src/components/FooterComponent.tsx'),
+      path.join(root, 'src/hooks/useDashboard.ts'),
+      path.join(root, 'src/context/AppContext.ts'),
+      path.join(root, 'src/domain/orders/OrderDomainService.ts'),
+      path.join(root, 'src/application/orders/OrderApplicationService.ts'),
+      path.join(root, 'src/infrastructure/orders/OrderInfrastructureService.ts'),
+      path.join(root, 'packages/mcp/server.ts'),
+      path.join(root, 'src/engine/ContextEngine.ts'),
+      path.join(root, 'src/engine/ContextIndexerEngine.ts'),
+    ],
+    byName: new Map(),
+    byFile: new Map(),
+  };
+
+  const graph = [
+    { from: 'src/controllers/UserController.ts', to: 'src/services/UserService.ts' },
+    { from: 'src/controllers/AdminController.ts', to: 'src/services/AuditService.ts' },
+    { from: 'src/services/UserService.ts', to: 'src/repositories/UserRepository.ts' },
+  ];
+
+  const memory = new ArchitectureMemory(root);
+  await memory.refresh(symbolIndex, graph);
+
+  const summary = memory.summary();
+  const ids = summary.patterns.map(p => p.id);
+  ['layered-services', 'react-component-system', 'domain-driven-design', 'mcp-server-bundle', 'context-engine-core'].forEach(id => {
+    assert(ids.includes(id));
+  });
+
+  const annotated = memory.annotateResults('service controller architecture', [
+    { uri: 'src/controllers/UserController.ts', score: 0.5, meta: {} },
+  ])[0];
+
+  assert(Array.isArray(annotated.meta.architecture));
+  assert(annotated.meta.architecture.some(tag => tag.id === 'layered-services'));
+  assert(annotated.score > 0.5);
+
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/packages/thinking-tools-mcp/test/context/engine.quickScan.test.mjs
+++ b/packages/thinking-tools-mcp/test/context/engine.quickScan.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+export default async function testQuickScanFallback() {
+  const workspaceRoot = mkdtempSync(path.join(os.tmpdir(), 'ctx-workspace-'));
+  const ctxRoot = path.join(workspaceRoot, '.robinson-context');
+  const repoRoot = await fs.mkdtemp(path.join(workspaceRoot, 'repo-'));
+
+  process.env.WORKSPACE_ROOT = workspaceRoot;
+  process.env.CTX_ROOT = ctxRoot;
+  process.env.CTX_AUTO_WATCH = '0';
+
+  const filePath = path.join(repoRoot, 'src', 'feature', 'important.ts');
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    [
+      "export function importantThing() {",
+      "  const contextNeedle = 'quick scan makes sense';",
+      "  return contextNeedle;",
+      "}",
+    ].join('\n'),
+    'utf8',
+  );
+
+  const { clearCachedContextConfig } = await import('../../dist/context/config.js');
+  clearCachedContextConfig();
+  const engineModule = await import('../../dist/context/engine.js');
+  const engine = engineModule.ContextEngine.get(repoRoot);
+
+  const results = await engine.quickScan('context needle', 5);
+
+  assert.ok(Array.isArray(results) && results.length > 0, 'quickScan should return fallback hits');
+  const top = results[0];
+  assert.equal(top._method, 'lazy-scan');
+  assert.equal(top._provider, 'lexical-fallback');
+  assert.ok(top.uri.includes('important.ts'));
+  assert.equal(top.meta?.fallback, true);
+
+  await fs.rm(repoRoot, { recursive: true, force: true });
+  await fs.rm(ctxRoot, { recursive: true, force: true });
+  await fs.rm(workspaceRoot, { recursive: true, force: true });
+}

--- a/packages/thinking-tools-mcp/test/context/language-patterns.test.mjs
+++ b/packages/thinking-tools-mcp/test/context/language-patterns.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { extractSymbolMatches } from '../../dist/context/language-patterns.js';
+
+export default async function testLanguagePatterns() {
+  const pyText = [
+    'def _internal_helper():\n    pass',
+    '',
+    'def PublicFunction():\n    return True',
+    '',
+    'class _HiddenThing:\n    pass',
+    '',
+    'class PublicClass:\n    pass',
+  ].join('\n');
+
+  const pyMatches = extractSymbolMatches(pyText, '.py');
+  const pyNames = pyMatches.map(m => m.name);
+  assert(pyNames.includes('PublicFunction'));
+  assert(pyNames.includes('PublicClass'));
+  assert(pyNames.includes('_internal_helper'));
+  assert.equal(pyMatches.find(m => m.name === 'PublicFunction')?.exported, true);
+  assert.equal(pyMatches.find(m => m.name === '_HiddenThing')?.exported, false);
+  assert.equal(pyMatches.find(m => m.name === '_internal_helper')?.exported, false);
+
+  const goSource = [
+    'package sample',
+    '',
+    'func internalThing() {}',
+    '',
+    'func ExportedFunction() {}',
+    '',
+    'type secretStruct struct{}',
+    'type PublicStruct struct{}',
+  ].join('\n');
+
+  const goMatches = extractSymbolMatches(goSource, '.go');
+  assert(goMatches.some(m => m.name === 'ExportedFunction' && m.exported));
+  assert(goMatches.some(m => m.name === 'PublicStruct' && m.exported));
+  assert(goMatches.some(m => m.name === 'internalThing'));
+  assert.equal(goMatches.find(m => m.name === 'internalThing')?.exported, false);
+  assert(goMatches.some(m => m.name === 'secretStruct'));
+  assert.equal(goMatches.find(m => m.name === 'secretStruct')?.exported, false);
+
+  const rustSource = [
+    'pub enum ExportedEnum { One }',
+    'pub mod exposed_module {',
+    '  pub fn inside() {}',
+    '}',
+    'fn private_helper() {}',
+    'pub fn public_api() {}',
+    'pub struct VisibleStruct {}',
+    'struct HiddenStruct {}',
+  ].join('\n');
+
+  const rustMatches = extractSymbolMatches(rustSource, '.rs');
+  ['public_api', 'VisibleStruct', 'exposed_module', 'ExportedEnum'].forEach(name => {
+    const match = rustMatches.find(m => m.name === name);
+    assert(match, `expected rust symbol ${name}`);
+    assert.equal(match.exported, true);
+  });
+  const privateFn = rustMatches.find(m => m.name === 'private_helper');
+  assert(privateFn);
+  assert.equal(privateFn.exported, false);
+}

--- a/packages/thinking-tools-mcp/test/run-tests.mjs
+++ b/packages/thinking-tools-mcp/test/run-tests.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+
+const tests = [
+  () => import('./context/engine.quickScan.test.mjs'),
+  () => import('./context/language-patterns.test.mjs'),
+  () => import('./context/architecture.test.mjs'),
+];
+
+let passed = 0;
+for (const load of tests) {
+  const mod = await load();
+  assert.equal(typeof mod.default, 'function', 'test module must export default function');
+  await mod.default();
+  passed += 1;
+}
+
+console.log(`✅ Ran ${passed} context engine checks`);


### PR DESCRIPTION
## Summary
- add lightweight node-based tests covering quick scan fallback, multi-language symbol parsing, and architecture annotations
- wire a simple test runner into the thinking-tools MCP package so `pnpm test` builds and executes the new checks

## Testing
- `pnpm --filter @robinson_ai_systems/thinking-tools-mcp test`


------
https://chatgpt.com/codex/tasks/task_e_690ad0db6ed8832ba8dd19f9726de8ba