### PR TITLE
Sanitize free agent outputs for plain text clients

### DIFF
--- a/packages/free-agent-mcp/src/agents/code-analyzer.ts
+++ b/packages/free-agent-mcp/src/agents/code-analyzer.ts
@@ -7,6 +7,7 @@
 
 import { OllamaClient, GenerateOptions } from '../ollama-client.js';
 import { PromptBuilder } from '../utils/prompt-builder.js';
+import { stripCodeFences } from '../utils/output-format.js';
 
 export interface AnalyzeRequest {
   code?: string;
@@ -56,9 +57,10 @@ export class CodeAnalyzer {
     };
 
     const result = await this.ollama.generate(prompt, options);
+    const analysisText = stripCodeFences(result.text);
 
     // Parse issues from the analysis
-    const issues = this.parseIssues(result.text);
+    const issues = this.parseIssues(analysisText);
 
     // Calculate credit savings
     // Augment would use ~5,000 credits for analysis
@@ -67,7 +69,7 @@ export class CodeAnalyzer {
     const creditsSaved = 5000 - augmentCreditsUsed;
 
     return {
-      analysis: result.text,
+      analysis: analysisText,
       issues,
       augmentCreditsUsed,
       creditsSaved,

--- a/packages/free-agent-mcp/src/agents/code-refactor.ts
+++ b/packages/free-agent-mcp/src/agents/code-refactor.ts
@@ -9,7 +9,7 @@ import { OllamaClient, GenerateOptions } from '../ollama-client.js';
 import { PromptBuilder } from '../utils/prompt-builder.js';
 import { iterateTask, PipelineResult } from '../pipeline/index.js';
 import { ValidationResult } from '../types/validation.js';
-import { formatGMCode, formatUnifiedDiffs, type OutputFile } from '../utils/output-format.js';
+import { formatGMCode, formatUnifiedDiffs, stripCodeFences, type OutputFile } from '../utils/output-format.js';
 
 export interface RefactorRequest {
   code: string;
@@ -90,7 +90,7 @@ Requirements:
 
     // Extract refactored code from pipeline result
     const mainFile = pipelineResult.files[0];
-    const code = mainFile?.content || request.code; // Fallback to original if failed
+    const code = stripCodeFences(mainFile?.content || request.code); // Fallback to original if failed
 
     // Extract changes from pipeline verdict
     const changes: Change[] = pipelineResult.verdict?.fix_plan?.map(fix => ({
@@ -116,7 +116,7 @@ Requirements:
 
     const detailedFiles: OutputFile[] = (pipelineResult.files ?? []).map((file, index) => ({
       path: file.path || `refactored-${index}.ts`,
-      content: file.content,
+      content: stripCodeFences(file.content || ''),
       originalContent: index === 0 ? request.code : undefined,
     }));
 

--- a/packages/free-agent-mcp/src/index.ts
+++ b/packages/free-agent-mcp/src/index.ts
@@ -49,7 +49,7 @@ import { FeedbackCapture, FeedbackSource } from './learning/feedback-capture.js'
 import { join } from 'path';
 import { homedir } from 'os';
 import { loadBetterSqlite } from './utils/sqlite.js';
-import { formatGMCode, formatUnifiedDiffs, type OutputFile } from './utils/output-format.js';
+import { formatGMCode, formatUnifiedDiffs, stripCodeFences, type OutputFile } from './utils/output-format.js';
 
 type VersatileTaskType =
   | 'code_generation'
@@ -1227,7 +1227,10 @@ Generate the modified section now:`;
 
     const filtered = files.filter(file => file);
     return {
-      files: filtered.filter(file => !file.deleted).map(file => ({ path: file.path, content: file.content })),
+      files: filtered.filter(file => !file.deleted).map(file => ({
+        path: file.path,
+        content: stripCodeFences(file.content || ''),
+      })),
       gmcode: formatGMCode(filtered),
       diff: formatUnifiedDiffs(filtered),
     };

--- a/packages/free-agent-mcp/src/utils/output-format.ts
+++ b/packages/free-agent-mcp/src/utils/output-format.ts
@@ -10,13 +10,28 @@ export interface OutputFile {
 /**
  * Format files as GMCode blocks for downstream agents.
  */
+export function stripCodeFences(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  let result = text.trim();
+  const fencePattern = /^```[\w+-]*\n([\s\S]*?)\n```$/;
+
+  while (fencePattern.test(result)) {
+    result = result.replace(fencePattern, '$1').trim();
+  }
+
+  return result;
+}
+
 export function formatGMCode(files: OutputFile[]): string {
   const blocks = files
     .filter(file => !file.deleted)
     .map(file => [
       '```gmcode',
       `path: ${file.path}`,
-      file.content,
+      stripCodeFences(file.content),
       '```'
     ].join('\n'));
 


### PR DESCRIPTION
## Summary
- add a shared helper to strip markdown code fences from generated text before formatting responses
- sanitize code generation, refactoring, testing, and documentation outputs to return plain text content to callers
- normalize file payloads sent through the MCP interface so downstream tools receive fence-free text

## Testing
- pnpm --filter @robinson_ai_systems/free-agent-mcp build *(fails: TypeScript config lacks Node lib declarations in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_690c27c00ed4832b80a68f99a317cdd2