### PR TITLE
Improve tool responses and Voyage endpoint handling

### DIFF
--- a/packages/paid-agent-mcp/src/index.ts
+++ b/packages/paid-agent-mcp/src/index.ts
@@ -95,7 +95,14 @@ async function callVoyageChatCompletion(params: {
     throw new Error('Voyage API key missing. Set VOYAGE_API_KEY or reuse ANTHROPIC_API_KEY');
   }
 
-  const baseUrl = (process.env.VOYAGE_BASE_URL || 'https://api.voyageai.com/v1').replace(/\/$/, '');
+  const rawBaseUrl = process.env.VOYAGE_BASE_URL || 'https://api.voyageai.com/v1';
+  let baseUrl = rawBaseUrl.replace(/\/+$/, '');
+
+  // Some configurations point directly at the embeddings endpoint. Normalize so we can
+  // append `/chat/completions` without producing a 404 such as `/embeddings/chat/completions`.
+  if (/\/embeddings$/i.test(baseUrl)) {
+    baseUrl = baseUrl.replace(/\/embeddings$/i, '');
+  }
   const maxRetries = params.maxRetries ?? 3;
   let lastError: Error | null = null;
 


### PR DESCRIPTION
## Summary
- format the free agent's tool responses into MCP-compliant text chunks that surface summaries, gmcode, diffs, and metadata without forcing JSON parsing
- normalize the Voyage chat completion base URL so configs pointing at the embeddings endpoint no longer produce 404 errors

## Testing
- pnpm --filter free-agent-mcp build *(fails: workspace lacks installed node_modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690c27c00ed4832b80a68f99a317cdd2